### PR TITLE
feat: 買付取引の未実現損益を含めて取得できる機能を追加

### DIFF
--- a/src/api/stock/routes/transactions.py
+++ b/src/api/stock/routes/transactions.py
@@ -9,6 +9,7 @@ from ..schemas import (
     MonthlySummary,
     Transaction,
     TransactionCreate,
+    TransactionWithPL,
     User,
     YearlySummary,
 )
@@ -41,10 +42,11 @@ async def create_transaction(
         raise HTTPException(status_code=404, detail="Stock not found")
 
 
-@router.get("/", response_model=List[Transaction])
+@router.get("/", response_model=List[Transaction | TransactionWithPL])
 async def list_transactions(
     current_user: Annotated[User, Depends(get_current_user)],
     symbol: Optional[str] = Query(None, description="シンボルでフィルタリング"),
+    include_unrealized_pl: bool = Query(False, description="買付に未実現損益を含める（symbolと併用）"),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -52,9 +54,10 @@ async def list_transactions(
     - 成功時: 取引情報のリストを返却（日付降順）
     - 返却データには、銘柄名(stock_name)も含まれる
     - symbolパラメータを指定すると、該当する銘柄のみをフィルタリングして返却
+    - include_unrealized_pl=trueかつsymbol指定時、買付取引に未実現損益（unrealized_pl, unrealized_pl_percentage）を含める
     """
     transaction_service = TransactionService(db)
-    return await transaction_service.list_transactions(current_user.user_id, symbol)
+    return await transaction_service.list_transactions(current_user.user_id, symbol, include_unrealized_pl)
 
 
 @router.get("/monthly-summary", response_model=List[MonthlySummary])

--- a/src/api/stock/schemas.py
+++ b/src/api/stock/schemas.py
@@ -166,6 +166,13 @@ class Transaction(TransactionBase):
         return to_jst(v).isoformat() if v else None
 
 
+class TransactionWithPL(Transaction):
+    """買付損益情報を含む取引情報"""
+
+    unrealized_pl: Optional[Decimal] = None  # 未実現損益金額（現在価格×数量 - 取得価格×数量）
+    unrealized_pl_percentage: Optional[Decimal] = None  # 未実現損益率（%）
+
+
 class PortfolioHistoryBase(BaseModel):
     date: datetime
     total_cost: Decimal

--- a/src/api/stock/services/transaction_service.py
+++ b/src/api/stock/services/transaction_service.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional
+from decimal import Decimal
+from typing import Dict, List, Optional, Union
 
 from sqlalchemy import extract, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,6 +8,7 @@ from .. import models, schemas
 from .holding_service import (
     calculate_holding_from_transactions,
     calculate_realized_pl_from_transactions,
+    list_holdings,
     update_single_holding_pl,
 )
 from .stock_service import StockService
@@ -102,7 +104,9 @@ class TransactionService:
             self.db, holding.user_id, holding.symbol
         )
 
-    async def list_transactions(self, user_id: int, symbol: Optional[str] = None) -> List[models.Transaction]:
+    async def list_transactions(
+        self, user_id: int, symbol: Optional[str] = None, include_unrealized_pl: bool = False
+    ) -> Union[List[models.Transaction], List[schemas.TransactionWithPL]]:
         # 銘柄名を取得するためにStockテーブルを結合
         query = (
             select(models.Transaction, models.Stock.name)
@@ -121,6 +125,48 @@ class TransactionService:
             transaction = row[0]
             transaction.stock_name = row[1]
             transactions.append(transaction)
+
+        # 未実現損益を含める場合
+        if include_unrealized_pl and symbol:
+            # holdingから現在価格を取得
+            holdings = await list_holdings(self.db, user_id, symbol)
+            current_price = holdings[0].current_price if holdings and holdings[0].current_price else None
+
+            # 各買付取引に対して損益を計算
+            transactions_with_pl = []
+            for transaction in transactions:
+                transaction_dict = {
+                    "transaction_id": transaction.transaction_id,
+                    "user_id": transaction.user_id,
+                    "symbol": transaction.symbol,
+                    "transaction_type": transaction.transaction_type,
+                    "quantity": transaction.quantity,
+                    "price": transaction.price,
+                    "usd_price": transaction.usd_price,
+                    "adjusted_price": transaction.adjusted_price,
+                    "account_type": transaction.account_type,
+                    "fee": transaction.fee,
+                    "tax": transaction.tax,
+                    "realized_pl": transaction.realized_pl,
+                    "transaction_date": transaction.transaction_date,
+                    "stock_name": transaction.stock_name,
+                    "unrealized_pl": None,
+                    "unrealized_pl_percentage": None,
+                }
+
+                # 買付取引の場合のみ損益を計算
+                if transaction.transaction_type == "buy" and current_price:
+                    cost = transaction.price * transaction.quantity
+                    market_value = current_price * transaction.quantity
+                    unrealized_pl = market_value - cost
+                    unrealized_pl_percentage = (unrealized_pl / cost * 100) if cost > 0 else Decimal("0")
+                    transaction_dict["unrealized_pl"] = unrealized_pl
+                    transaction_dict["unrealized_pl_percentage"] = unrealized_pl_percentage
+
+                transactions_with_pl.append(schemas.TransactionWithPL(**transaction_dict))
+
+            return transactions_with_pl
+
         return transactions
 
     async def get_monthly_summary(self, user_id: int) -> List[Dict]:

--- a/src/api/tests/api/test_transactions.py
+++ b/src/api/tests/api/test_transactions.py
@@ -411,3 +411,119 @@ async def test_list_transactions(client: AsyncClient, db_session: AsyncSession, 
     data = response.json()
     assert len(data) > 0
     assert data[0]["stock_name"] == "三菱商事"
+
+
+@pytest.mark.asyncio
+async def test_list_transactions_with_unrealized_pl(
+    client: AsyncClient, db_session: AsyncSession, auth_token: str
+):
+    """買付取引に未実現損益を含めて取得するテスト
+
+    期待する動作:
+    - include_unrealized_pl=trueかつsymbol指定時、買付取引に未実現損益が含まれる
+    - 売却取引には未実現損益が含まれない（null）
+
+    Args:
+        client: 非同期HTTPクライアント
+        db_session: テスト用DBセッション
+        auth_token: 認証トークン
+    """
+    # 事前に購入取引を登録
+    buy_transaction = {
+        "symbol": "8058",
+        "transaction_type": "buy",
+        "quantity": "10.0",
+        "price": "3000.0",
+        "account_type": "NISA(成長投資枠)",
+        "fee": "0.0",
+        "tax": "0.0",
+        "transaction_date": "2024-01-01T00:00:00",
+    }
+    await client.post(
+        "/api/v1/transactions/", json=buy_transaction, headers={"Authorization": f"Bearer {auth_token}"}
+    )
+
+    # 売却取引を登録
+    sell_transaction = {
+        "symbol": "8058",
+        "transaction_type": "sell",
+        "quantity": "5.0",
+        "price": "3500.0",
+        "account_type": "NISA(成長投資枠)",
+        "fee": "0.0",
+        "tax": "0.0",
+        "transaction_date": "2024-01-02T00:00:00",
+    }
+    await client.post(
+        "/api/v1/transactions/", json=sell_transaction, headers={"Authorization": f"Bearer {auth_token}"}
+    )
+
+    # 未実現損益を含めて取引履歴を取得
+    response = await client.get(
+        "/api/v1/transactions/?symbol=8058&include_unrealized_pl=true",
+        headers={"Authorization": f"Bearer {auth_token}"},
+    )
+
+    # レスポンスの検証
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+
+    # 日付降順で返されるので、売却が先
+    sell_data = data[0]  # 売却取引
+    buy_data = data[1]  # 買付取引
+
+    # 売却取引には未実現損益がnull
+    assert sell_data["transaction_type"] == "sell"
+    assert sell_data["unrealized_pl"] is None
+    assert sell_data["unrealized_pl_percentage"] is None
+
+    # 買付取引には未実現損益が含まれる
+    assert buy_data["transaction_type"] == "buy"
+    assert buy_data["unrealized_pl"] is not None
+    assert buy_data["unrealized_pl_percentage"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_transactions_without_unrealized_pl(
+    client: AsyncClient, db_session: AsyncSession, auth_token: str
+):
+    """include_unrealized_pl未指定時のテスト（デフォルトはfalse）
+
+    期待する動作:
+    - パラメータ未指定時は従来通りの動作（損益情報なし）
+
+    Args:
+        client: 非同期HTTPクライアント
+        db_session: テスト用DBセッション
+        auth_token: 認証トークン
+    """
+    # 事前に購入取引を登録
+    transaction_data = {
+        "symbol": "8058",
+        "transaction_type": "buy",
+        "quantity": "10.0",
+        "price": "3000.0",
+        "account_type": "NISA(成長投資枠)",
+        "fee": "0.0",
+        "tax": "0.0",
+        "transaction_date": "2024-01-01T00:00:00",
+    }
+    await client.post(
+        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
+    )
+
+    # include_unrealized_plを指定せずに取引履歴を取得
+    response = await client.get(
+        "/api/v1/transactions/?symbol=8058",
+        headers={"Authorization": f"Bearer {auth_token}"},
+    )
+
+    # レスポンスの検証
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+
+    # 未実現損益フィールドがレスポンスに含まれていないことを確認
+    assert "unrealized_pl" not in data[0]
+    assert "unrealized_pl_percentage" not in data[0]


### PR DESCRIPTION
## Summary
- list_transactions APIにinclude_unrealized_plオプションを追加
- 買付取引に対して未実現損益（金額と率）を返却

Closes #53

## Test plan
- [] `include_unrealized_pl=true`かつ`symbol`指定時に買付取引に未実現損益が含まれる
- [] 売却取引には未実現損益がnull
- [] パラメータ未指定時は従来通り

🤖 Generated with [Claude Code](https://claude.ai/claude-code)