### PR TITLE
feat: Vercel Preview URLに対応したCORS設定を追加

### DIFF
--- a/src/api/stock/app.py
+++ b/src/api/stock/app.py
@@ -20,6 +20,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
+    allow_origin_regex=r"^https://.+-tomodo1773s-projects\.vercel\.app$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## 概要

VercelのPreview環境からのAPIアクセスを可能にするため、CORS設定に `allow_origin_regex` を追加しました。

## 変更内容

- `src/api/stock/app.py` のCORS設定に `allow_origin_regex` を追加
- 正規表現: `^https://.+-tomodo1773s-projects\.vercel\.app$`
- アカウント固有の識別子で制限し、セキュリティを確保

## テスト

- 全76テストが成功
- 既存機能に影響なし

Closes #87

---

Generated with [Claude Code](https://claude.ai/code)