### PR TITLE
feat: ログイン保持時間を1日に変更

### DIFF
--- a/src/api/stock/auth.py
+++ b/src/api/stock/auth.py
@@ -19,7 +19,7 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 SECRET_KEY = settings.JWT_SECRET_KEY
 # アルゴリズムとトークン有効期限は固定値として定義
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 1日
 
 # OAuth2スキームを更新してOAuthエンドポイントを指すように
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/oauth/token")


### PR DESCRIPTION
## 概要
ログイン保持時間を30分から1日(1440分)に延長しました。

## 変更内容
- `src/api/stock/auth.py`の`ACCESS_TOKEN_EXPIRE_MINUTES`を30から1440に変更

## 関連Issue
Closes #107

---
🤖 Generated with [Claude Code](https://claude.ai/code)