### PR TITLE
fix: PWAアイコンのmaskable対応とbackground_colorを緑色に変更

### DIFF
--- a/src/web/public/site.webmanifest
+++ b/src/web/public/site.webmanifest
@@ -2,10 +2,32 @@
   "name": "InvestLogix - Portfolio Manager",
   "short_name": "InvestLogix",
   "icons": [
-    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
   ],
   "theme_color": "#2D9B81",
-  "background_color": "#ffffff",
+  "background_color": "#2D9B81",
   "display": "standalone"
 }


### PR DESCRIPTION
Closes #84

## 変更内容
- iconsにpurpose: any/maskableを追加してAndroid Adaptive Icon対応
- background_colorを#ffffffから#2D9B81に変更し、アイコン周りの白枠を解消

Generated with [Claude Code](https://claude.ai/code)