### PR TITLE
feat: 銘柄別保有割合円グラフにsecurity_typeフィルタ機能を追加

### DIFF
--- a/src/web/docs/TEST_LIST.md
+++ b/src/web/docs/TEST_LIST.md
@@ -98,6 +98,17 @@
 - [x] 20銘柄以下の場合は「その他」が追加されない
 - [x] `market_value` が null または空文字の場合は0として扱われフィルタリングされる
 
+#### `transformHoldingsToChartData` - フィルタ機能
+
+- [x] フィルタなし（ALL）の場合、すべてのsecurity_typeが表示される
+- [x] STOCKフィルタで株式のみが表示される
+- [x] ETFフィルタでETFのみが表示される
+- [x] FUNDフィルタで投資信託のみが表示される
+- [x] REITフィルタでREITのみが表示される
+- [x] フィルタ適用後も上位20銘柄制限が機能する
+- [x] フィルタ条件に一致する銘柄がない場合は空配列を返す
+- [x] `security_type` が null の銘柄はフィルタで除外される
+
 ### 状態管理 (`lib/stores/auth-store.ts`)
 
 #### `useAuthStore`

--- a/src/web/src/components/dashboard/holding-allocation-chart.test.ts
+++ b/src/web/src/components/dashboard/holding-allocation-chart.test.ts
@@ -3,7 +3,12 @@ import type { Holding } from "@/lib/api/types"
 import { transformHoldingsToChartData } from "./holding-allocation-chart"
 
 describe("transformHoldingsToChartData", () => {
-  const createHolding = (symbol: string, marketValue: string, stockName: string | null = null): Holding => ({
+  const createHolding = (
+    symbol: string,
+    marketValue: string,
+    stockName: string | null = null,
+    securityType: string | null = "STOCK"
+  ): Holding => ({
     symbol,
     quantity: "100",
     average_cost: "1000",
@@ -17,7 +22,7 @@ describe("transformHoldingsToChartData", () => {
     user_id: 1,
     last_updated: "2024-01-01",
     stock_name: stockName,
-    security_type: "stock",
+    security_type: securityType,
     currency: "JPY",
   })
 
@@ -127,5 +132,113 @@ describe("transformHoldingsToChartData", () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].symbol).toBe("AAPL")
+  })
+
+  describe("フィルタ機能", () => {
+    it("フィルタなし（ALL）の場合、すべてのsecurity_typeが表示される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("VTI", "800000", "Vanguard Total Stock", "ETF"),
+        createHolding("REIT1", "600000", "REIT1", "REIT"),
+        createHolding("FUND1", "400000", "Fund1", "FUND"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "ALL")
+
+      expect(result).toHaveLength(4)
+      expect(result.map((item) => item.symbol)).toEqual(["AAPL", "VTI", "REIT1", "FUND1"])
+    })
+
+    it("STOCKフィルタで株式のみが表示される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("GOOGL", "900000", "Google", "STOCK"),
+        createHolding("VTI", "800000", "Vanguard Total Stock", "ETF"),
+        createHolding("REIT1", "600000", "REIT1", "REIT"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "STOCK")
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.symbol)).toEqual(["AAPL", "GOOGL"])
+    })
+
+    it("ETFフィルタでETFのみが表示される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("VTI", "900000", "Vanguard Total Stock", "ETF"),
+        createHolding("VOO", "800000", "Vanguard S&P 500", "ETF"),
+        createHolding("REIT1", "600000", "REIT1", "REIT"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "ETF")
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.symbol)).toEqual(["VTI", "VOO"])
+    })
+
+    it("FUNDフィルタで投資信託のみが表示される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("FUND1", "900000", "Fund1", "FUND"),
+        createHolding("FUND2", "800000", "Fund2", "FUND"),
+        createHolding("VTI", "700000", "Vanguard Total Stock", "ETF"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "FUND")
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.symbol)).toEqual(["FUND1", "FUND2"])
+    })
+
+    it("REITフィルタでREITのみが表示される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("REIT1", "900000", "REIT1", "REIT"),
+        createHolding("REIT2", "800000", "REIT2", "REIT"),
+        createHolding("VTI", "700000", "Vanguard Total Stock", "ETF"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "REIT")
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.symbol)).toEqual(["REIT1", "REIT2"])
+    })
+
+    it("フィルタ適用後も上位20銘柄制限が機能する", () => {
+      const holdings: Holding[] = Array.from({ length: 25 }, (_, i) =>
+        createHolding(`STOCK${i + 1}`, ((30 - i) * 10000).toString(), `株式${i + 1}`, "STOCK")
+      )
+
+      const result = transformHoldingsToChartData(holdings, "STOCK")
+
+      // 上位20銘柄 + その他 = 21件
+      expect(result).toHaveLength(21)
+      expect(result[result.length - 1].symbol).toBe("OTHER")
+    })
+
+    it("フィルタ条件に一致する銘柄がない場合は空配列を返す", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("GOOGL", "900000", "Google", "STOCK"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "ETF")
+
+      expect(result).toEqual([])
+    })
+
+    it("security_typeがnullの銘柄はフィルタで除外される", () => {
+      const holdings: Holding[] = [
+        createHolding("AAPL", "1000000", "Apple", "STOCK"),
+        createHolding("UNKNOWN", "900000", "Unknown", null),
+        createHolding("GOOGL", "800000", "Google", "STOCK"),
+      ]
+
+      const result = transformHoldingsToChartData(holdings, "STOCK")
+
+      expect(result).toHaveLength(2)
+      expect(result.map((item) => item.symbol)).toEqual(["AAPL", "GOOGL"])
+    })
   })
 })

--- a/src/web/src/components/dashboard/holding-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/holding-allocation-chart.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Holding } from "@/lib/api/types"
 import { formatCurrency } from "@/lib/format"
@@ -36,6 +37,18 @@ const COLORS = [
 // 「その他」用の色
 const OTHER_COLOR = "#BDBDBD"
 
+// フィルタータイプ
+type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
+
+// フィルタボタンの設定
+const FILTER_OPTIONS: { value: SecurityTypeFilter; label: string }[] = [
+  { value: "ALL", label: "すべて" },
+  { value: "STOCK", label: "株式" },
+  { value: "ETF", label: "ETF" },
+  { value: "FUND", label: "投信" },
+  { value: "REIT", label: "REIT" },
+]
+
 export interface ChartDataItem {
   name: string
   symbol: string
@@ -46,12 +59,23 @@ export interface ChartDataItem {
 /**
  * 保有銘柄データを円グラフ用に変換する
  * 上位20銘柄を個別に表示し、21位以降は「その他」として集約する
+ * @param holdings 保有銘柄データ
+ * @param filter セキュリティタイプフィルタ（デフォルト: "ALL"）
  */
-export function transformHoldingsToChartData(holdings: Holding[] | undefined): ChartDataItem[] {
+export function transformHoldingsToChartData(
+  holdings: Holding[] | undefined,
+  filter: SecurityTypeFilter = "ALL"
+): ChartDataItem[] {
   if (!holdings || holdings.length === 0) return []
 
+  // フィルタを適用
+  let filteredHoldings = holdings
+  if (filter !== "ALL") {
+    filteredHoldings = holdings.filter((holding) => holding.security_type === filter)
+  }
+
   // 評価額でソート
-  const sortedHoldings = [...holdings]
+  const sortedHoldings = [...filteredHoldings]
     .map((holding) => ({
       symbol: holding.symbol,
       name: holding.stock_name || holding.symbol,
@@ -86,18 +110,25 @@ export function transformHoldingsToChartData(holdings: Holding[] | undefined): C
 }
 
 export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationChartProps) {
-  const chartData = useMemo(() => transformHoldingsToChartData(data), [data])
+  const [filter, setFilter] = useState<SecurityTypeFilter>("ALL")
+  const chartData = useMemo(() => transformHoldingsToChartData(data, filter), [data, filter])
 
   // 全体の合計を計算（パーセンテージ表示用）
   const total = useMemo(() => {
     return chartData.reduce((sum, item) => sum + item.value, 0)
   }, [chartData])
 
+  // フィルタに応じたタイトルを生成
+  const chartTitle = useMemo(() => {
+    const filterLabel = FILTER_OPTIONS.find((option) => option.value === filter)?.label || "すべて"
+    return filter === "ALL" ? "銘柄別保有割合" : `${filterLabel}の銘柄別保有割合`
+  }, [filter])
+
   if (isLoading) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>銘柄別保有割合</CardTitle>
+          <CardTitle>{chartTitle}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="h-80 animate-pulse rounded bg-muted" />
@@ -106,68 +137,71 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
     )
   }
 
-  if (!chartData.length) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>銘柄別保有割合</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex h-80 items-center justify-center text-muted-foreground">
-            データがありません
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
-
   return (
     <Card>
       <CardHeader>
-        <CardTitle>銘柄別保有割合</CardTitle>
+        <CardTitle>{chartTitle}</CardTitle>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {FILTER_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              variant={filter === option.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => setFilter(option.value)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
       </CardHeader>
       <CardContent>
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, value }) => {
-                  const percent = ((value / total) * 100).toFixed(1)
-                  // 小さいセクター（2%未満）はラベルを省略
-                  if (parseFloat(percent) < 2) return ""
-                  return `${name} ${percent}%`
-                }}
-                outerRadius={120}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {chartData.map((entry, index) => (
-                  <Cell
-                    key={`cell-${entry.symbol}`}
-                    fill={entry.symbol === "OTHER" ? OTHER_COLOR : COLORS[index % COLORS.length]}
-                  />
-                ))}
-              </Pie>
-              <Tooltip
-                formatter={(value: number | undefined, _name: string | undefined, props: unknown) => {
-                  const percent = ((value ?? 0) / total) * 100
-                  const payload = props as { payload: { name: string } }
-                  return [`${formatCurrency(value ?? 0)} (${percent.toFixed(2)}%)`, payload.payload.name]
-                }}
-                labelFormatter={(label, payload) => {
-                  if (payload && payload.length > 0) {
-                    return payload[0].payload.name
-                  }
-                  return label
-                }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
+        {!chartData.length ? (
+          <div className="flex h-80 items-center justify-center text-muted-foreground">
+            データがありません
+          </div>
+        ) : (
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={({ name, value }) => {
+                    const percent = ((value / total) * 100).toFixed(1)
+                    // 小さいセクター（2%未満）はラベルを省略
+                    if (parseFloat(percent) < 2) return ""
+                    return `${name} ${percent}%`
+                  }}
+                  outerRadius={120}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell
+                      key={`cell-${entry.symbol}`}
+                      fill={entry.symbol === "OTHER" ? OTHER_COLOR : COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value: number | undefined, _name: string | undefined, props: unknown) => {
+                    const percent = ((value ?? 0) / total) * 100
+                    const payload = props as { payload: { name: string } }
+                    return [`${formatCurrency(value ?? 0)} (${percent.toFixed(2)}%)`, payload.payload.name]
+                  }}
+                  labelFormatter={(label, payload) => {
+                    if (payload && payload.length > 0) {
+                      return payload[0].payload.name
+                    }
+                    return label
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## 概要

Closes #124

銘柄別保有割合円グラフにsecurity_typeによるフィルタ機能を追加しました。ユーザーは「すべて」「株式」「ETF」「投信」「REIT」を選択でき、選択に応じて円グラフの表示内容が動的に変更されます。

## 主な変更点

- フィルタUI追加（ボタングループ）
- `transformHoldingsToChartData`関数に`filter`引数を追加
- フィルタ適用時のタイトル動的変更
- フィルタ機能の包括的なテストを追加（8テストケース）

## テスト

- ✅ 64テスト全て成功
- ✅ `pnpm check` 完了（lint, format, typecheck, knip）

Generated with [Claude Code](https://claude.ai/code)