### PR TITLE
fix: 株価グラフの線が表示されない問題を修正

### DIFF
--- a/src/web/src/components/stock/price-chart.tsx
+++ b/src/web/src/components/stock/price-chart.tsx
@@ -113,13 +113,7 @@ export function PriceChart({ symbol, securityType }: PriceChartProps) {
                 }}
                 formatter={(value: number | undefined) => [value?.toLocaleString() ?? "0", "終値"]}
               />
-              <Line
-                type="monotone"
-                dataKey="close"
-                stroke="hsl(var(--primary))"
-                strokeWidth={2}
-                dot={false}
-              />
+              <Line type="monotone" dataKey="close" stroke="var(--primary)" strokeWidth={2} dot={false} />
             </LineChart>
           </ResponsiveContainer>
         ) : (


### PR DESCRIPTION
## 概要

銘柄詳細画面の株価グラフで線が表示されない問題を修正しました。

## 変更内容

- `price-chart.tsx`の`stroke`属性を`hsl(var(--primary))`から`var(--primary)`に変更
- CSS変数がHEX形式で定義されているたあ、`hsl()`関数での使用は無効
- 直接`var()`で参照することで正しく色が適用される

Fixes #133

---

Generated with [Claude Code](https://claude.ai/code)