### PR TITLE
feat: docker-composeでDB_HOSTを上書き設定

### DIFF
--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -24,6 +24,10 @@ services:
       context: ./api
       dockerfile: Dockerfile
     container_name: investlogix-api
+    env_file:
+      - ./api/.env
+    environment:
+      DB_HOST: db
     volumes:
       - ./api:/src
       - ./api/.dockervenv:/src/.venv


### PR DESCRIPTION
## 概要

docker-compose起動時にDB_HOSTだけを上書きする設定を追加しました。

## 変更内容

- apiサービスにenv_fileとenvironment設定を追加
- .envファイルの値を読み込みつつ、DB_HOSTだけを"db"に上書き
- これによりdocker-compose起動時に適切なホスト名でDBに接続可能

Closes #132

Generated with [Claude Code](https://claude.ai/code)