### PR TITLE
fix: タブレット画面下部のブランクスペース問題を修正

### DIFF
--- a/src/web/src/components/layout/app-layout.tsx
+++ b/src/web/src/components/layout/app-layout.tsx
@@ -18,7 +18,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-dvh">
       <Sidebar />
       <div className="flex flex-1 flex-col">
         <header className="border-b bg-card">


### PR DESCRIPTION
## 概要

`h-screen`（100vh）を`h-dvh`（動的ビューポート高さ）に変更し、タブレットブラウザで発生していた画面下部のブランクスペース問題を修正しました。

## 変更内容

- `src/web/src/components/layout/app-layout.tsx`のメイン`div`のクラスを`h-screen`から`h-dvh`に変更

## 解決する問題

Fixes #142

---

Generated with [Claude Code](https://claude.ai/code)