### PR TITLE
fix(dividend): unrealized_plの不正な計算コードを削除

### DIFF
--- a/src/api/stock/services/dividend_service.py
+++ b/src/api/stock/services/dividend_service.py
@@ -60,16 +60,7 @@ class DividendService:
                 net_dividend -= Decimal(dividend.fee)
 
             holding.total_dividend = (holding.total_dividend or Decimal("0")) + net_dividend
-            # 未実現損益の更新
-            if holding.market_value is not None:
-                holding.unrealized_pl = (
-                    holding.market_value
-                    + (holding.realized_pl or Decimal("0"))
-                    + holding.total_dividend
-                    - holding.total_cost
-                )
-                if holding.total_cost > 0:
-                    holding.unrealized_pl_percentage = (holding.unrealized_pl / holding.total_cost) * 100
+            # 注: unrealized_pl等の損益計算はupdate_single_holding_plに一元化
 
         await self.db.commit()
         await self.db.refresh(db_dividend)


### PR DESCRIPTION
## Summary
`dividend_service.py`でのunrealized_plの計算が誤ってrealized_plとtotal_dividendを含んでいた問題を修正しました。

## Changes
- unrealized_plの不正な計算ロジックを削除し、`update_single_holding_pl()`に一本化
- total_plとtotal_pl_percentageカラムを追加
- 不要なAlembic制約を削除
- その他の細かい修正とリファクタリング

## Related Issue
Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)