### PR TITLE
fix: ポートフォリオ通知をunrealized PLからtotal PLに変更

### DIFF
--- a/src/api/stock/services/notification_service.py
+++ b/src/api/stock/services/notification_service.py
@@ -58,13 +58,13 @@ class NotificationService:
             # ポートフォリオデータのフォーマット
             total_cost = _format_currency(portfolio_data["total_cost"])
             total_market_value = _format_currency(portfolio_data["total_market_value"])
-            total_unrealized_pl = _format_currency(portfolio_data["total_unrealized_pl"])
-            total_unrealized_pl_percentage = _format_decimal(portfolio_data["total_unrealized_pl_percentage"])
+            total_pl = _format_currency(portfolio_data["total_pl"])
+            total_pl_percentage = _format_decimal(portfolio_data["total_pl_percentage"])
             total_realized_pl = _format_currency(portfolio_data["total_realized_pl"])
             total_dividend = _format_currency(portfolio_data["total_dividend"])
 
             # 損益に応じたコメント
-            comment = _generate_comment(portfolio_data["total_unrealized_pl_percentage"])
+            comment = _generate_comment(portfolio_data["total_pl_percentage"])
 
             # LINEのFlex Message作成
             flex_contents = {
@@ -148,16 +148,16 @@ class NotificationService:
                                     "contents": [
                                         {
                                             "type": "text",
-                                            "text": "評価損益",
+                                            "text": "総損益",
                                             "size": "sm",
                                             "color": "#555555",
                                         },
                                         {
                                             "type": "text",
-                                            "text": f"{total_unrealized_pl}円 ({total_unrealized_pl_percentage}%)",
+                                            "text": f"{total_pl}円 ({total_pl_percentage}%)",
                                             "size": "sm",
                                             "color": _get_profit_loss_color(
-                                                float(portfolio_data["total_unrealized_pl_percentage"])
+                                                float(portfolio_data["total_pl_percentage"])
                                             ),
                                             "align": "end",
                                         },

--- a/src/api/stock/services/portfolio_service.py
+++ b/src/api/stock/services/portfolio_service.py
@@ -159,8 +159,8 @@ class PortfolioService:
         portfolio_data = {
             "total_cost": portfolio_history.total_cost,
             "total_market_value": portfolio_history.total_market_value,
-            "total_unrealized_pl": portfolio_history.total_unrealized_pl,
-            "total_unrealized_pl_percentage": portfolio_history.total_unrealized_pl_percentage,
+            "total_pl": portfolio_history.total_pl,
+            "total_pl_percentage": portfolio_history.total_pl_percentage,
             "total_realized_pl": portfolio_history.total_realized_pl,
             "total_dividend": portfolio_history.total_dividend,
         }


### PR DESCRIPTION
## 概要

ポートフォリオ通知でunrealized PL（評価損益）ではなくtotal PL（総損益）を通知するように変更しました。

## 変更内容

- `portfolio_service.py`: `portfolio_data`にtotal_plとtotal_pl_percentageを含めるように変更
- `notification_service.py`: 通知に使用する損益指標をtotal_pl/total_pl_percentageに変更
- LINE通知の表示ラベルを「評価損益」から「総損益」に変更
- アドバイザーコメント生成もtotal_pl_percentageを使用するように変更

## 影響

**total_pl** = 未実現損益 + 実現損益 + 反当総額

これにより、ポートフォリオ通知では評価損益だけでなく、実現損益と配当も含めた総合的な損益が表示されるようになります。

Closes #189

Generated with [Claude Code](https://claude.ai/code)