### PR TITLE
fix: サイドバーのNavLink end プロパティを完全一致に修正

### DIFF
--- a/src/web/src/components/layout/sidebar.tsx
+++ b/src/web/src/components/layout/sidebar.tsx
@@ -95,7 +95,7 @@ export function Sidebar() {
               <NavLink
                 key={item.to}
                 to={item.to}
-                end={item.to === "/"}
+                end={true}
                 className={({ isActive }) =>
                   `flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                     isCollapsed ? "justify-center" : "gap-3"


### PR DESCRIPTION
### 概要

CSVインポート(`/transactions/import`)をクリックした時に取引履歴(`/transactions`)も同時にフォーカスされる問題を修正。

### 変更内容

- React RouterのNavLinkコンポーネントの`end`プロパティを`true`に設定
- すべてのナビゲーション項目が完全一致の場合のみアクティブになるように修正

Fixes #202

---

Generated with [Claude Code](https://claude.ai/code)