### PR TITLE
fix: CSVインポートのaccept属性にMIMEタイプを追加してスマホ対応

### DIFF
--- a/src/web/src/components/transactions/csv-upload-form.tsx
+++ b/src/web/src/components/transactions/csv-upload-form.tsx
@@ -34,7 +34,7 @@ export function CsvUploadForm({ onFileSelect, isLoading }: CsvUploadFormProps) {
         <Input
           id="csv-file"
           type="file"
-          accept=".csv"
+          accept=".csv,text/csv"
           onChange={handleFileChange}
           disabled={isLoading}
           className="cursor-pointer"


### PR DESCRIPTION
Android/iOSのファイルピッカーでCSVファイルが表示されるよう、
accept属性に標準MIMEタイプ(text/csv)を追加しました。