### PR TITLE
fix: モバイルナビゲーションでCSVインポートクリック時に取引履歴がフォーカスされる問題を修正

### DIFF
--- a/src/web/src/components/layout/mobile-nav.tsx
+++ b/src/web/src/components/layout/mobile-nav.tsx
@@ -93,7 +93,7 @@ export function MobileNav() {
                 <NavLink
                   key={item.to}
                   to={item.to}
-                  end={item.to === "/"}
+                  end={true}
                   onClick={() => setOpen(false)}
                   className={({ isActive }) =>
                     `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${


### PR DESCRIPTION
NavLinkのendプロパティをデスクトップ版と同様にtrueに変更することで、
部分一致ではなく完全一致でのみナビゲーションアイテムがアクティブになるよう修正。
これにより、/transactions/importをクリックした際に/transactionsも
アクティブになってしまう問題を解決。

https://claude.ai/code/session_017ruQAoSfzFm5Ccpg14jUaQ