### PR TITLE
formatDate使用箇所の統一

### DIFF
--- a/src/web/src/components/portfolio-history/portfolio-history-table.tsx
+++ b/src/web/src/components/portfolio-history/portfolio-history-table.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { TablePagination } from "@/components/ui/table-pagination"
 import { useTableSort } from "@/hooks/use-table-sort"
 import type { PortfolioHistoryItem } from "@/lib/api/types"
-import { formatCurrency } from "@/lib/format"
+import { formatCurrency, formatDate } from "@/lib/format"
 import { usePagination } from "@/lib/hooks/use-pagination"
 
 interface PortfolioHistoryTableProps {
@@ -62,15 +62,6 @@ export function PortfolioHistoryTable({ history, isLoading }: PortfolioHistoryTa
   const handleSort = (key: SortKey) => {
     baseSortHandler(key)
     handlePageChange(1)
-  }
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
   }
 
   const formatPercentage = (value: number) => {

--- a/src/web/src/components/transactions/import-preview-table.tsx
+++ b/src/web/src/components/transactions/import-preview-table.tsx
@@ -2,6 +2,7 @@ import { Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import type { CsvTransactionPreview } from "@/lib/api/types"
+import { formatDate } from "@/lib/format"
 
 interface ImportPreviewTableProps {
   transactions: CsvTransactionPreview[]
@@ -10,15 +11,6 @@ interface ImportPreviewTableProps {
 }
 
 export function ImportPreviewTable({ transactions, onConfirm, isLoading }: ImportPreviewTableProps) {
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr)
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
-  }
-
   const formatNumber = (num: number | null) => {
     if (num === null) return "-"
     return num.toLocaleString("ja-JP")

--- a/src/web/src/components/transactions/transactions-table.tsx
+++ b/src/web/src/components/transactions/transactions-table.tsx
@@ -3,7 +3,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { TablePagination } from "@/components/ui/table-pagination"
 import { useTableSort } from "@/hooks/use-table-sort"
 import type { Transaction } from "@/lib/api/types"
-import { formatCurrency } from "@/lib/format"
+import { formatCurrency, formatDate } from "@/lib/format"
 import { usePagination } from "@/lib/hooks/use-pagination"
 
 interface TransactionsTableProps {
@@ -68,15 +68,6 @@ export function TransactionsTable({ transactions, isLoading }: TransactionsTable
   const handleSort = (key: SortKey) => {
     baseSortHandler(key)
     handlePageChange(1)
-  }
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
   }
 
   const getAccountTypeLabel = (accountType: string) => {


### PR DESCRIPTION
## 概要
ローカルに定義されていたformatDate関数を削除し、lib/format.tsの共通関数をインポートするように統一しました。

## 変更内容
- transactions-table.tsx: ローカルformatDate定義を削除し、lib/format.tsからインポート
- import-preview-table.tsx: ローカルformatDate定義を削除し、lib/format.tsからインポート
- portfolio-history-table.tsx: ローカルformatDate定義を削除し、lib/format.tsからインポート

## テスト
- pnpm check: ✅ 型チェック・リント・フォーマット確認完了
- pnpm test: ✅ 全テスト104件成功

Closes #233

Generated with [Claude Code](https://claude.ai/code)