### PR TITLE
refactor: navItemsを共通定数に抽出

### DIFF
--- a/src/web/src/components/layout/mobile-nav.tsx
+++ b/src/web/src/components/layout/mobile-nav.tsx
@@ -1,61 +1,8 @@
-import {
-  CircleDollarSign,
-  Database,
-  FileUp,
-  History,
-  LayoutDashboard,
-  Menu,
-  Receipt,
-  Scissors,
-  TrendingUp,
-  X,
-} from "lucide-react"
+import { Menu, X } from "lucide-react"
 import { useState } from "react"
 import { NavLink } from "react-router"
 import { Button } from "@/components/ui/button"
-
-const navItems = [
-  {
-    to: "/",
-    label: "ダッシュボード",
-    icon: LayoutDashboard,
-  },
-  {
-    to: "/holdings",
-    label: "保有状況",
-    icon: TrendingUp,
-  },
-  {
-    to: "/portfolio-history",
-    label: "資産推移",
-    icon: History,
-  },
-  {
-    to: "/transactions",
-    label: "取引履歴",
-    icon: Receipt,
-  },
-  {
-    to: "/transactions/import",
-    label: "CSVインポート",
-    icon: FileUp,
-  },
-  {
-    to: "/dividends",
-    label: "配当金履歴",
-    icon: CircleDollarSign,
-  },
-  {
-    to: "/stock-splits",
-    label: "株式分割履歴",
-    icon: Scissors,
-  },
-  {
-    to: "/stocks",
-    label: "銘柄マスター",
-    icon: Database,
-  },
-]
+import { navItems } from "@/constants/nav"
 
 export function MobileNav() {
   const [open, setOpen] = useState(false)

--- a/src/web/src/components/layout/sidebar.tsx
+++ b/src/web/src/components/layout/sidebar.tsx
@@ -1,62 +1,9 @@
-import {
-  CircleDollarSign,
-  Database,
-  FileUp,
-  History,
-  LayoutDashboard,
-  PanelLeft,
-  PanelLeftClose,
-  Receipt,
-  Scissors,
-  TrendingUp,
-} from "lucide-react"
+import { PanelLeft, PanelLeftClose } from "lucide-react"
 import { NavLink } from "react-router"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { navItems } from "@/constants/nav"
 import { useSidebarStore } from "@/lib/stores/sidebar-store"
-
-const navItems = [
-  {
-    to: "/",
-    label: "ダッシュボード",
-    icon: LayoutDashboard,
-  },
-  {
-    to: "/holdings",
-    label: "保有状況",
-    icon: TrendingUp,
-  },
-  {
-    to: "/portfolio-history",
-    label: "資産推移",
-    icon: History,
-  },
-  {
-    to: "/transactions",
-    label: "取引履歴",
-    icon: Receipt,
-  },
-  {
-    to: "/transactions/import",
-    label: "CSVインポート",
-    icon: FileUp,
-  },
-  {
-    to: "/dividends",
-    label: "配当金履歴",
-    icon: CircleDollarSign,
-  },
-  {
-    to: "/stock-splits",
-    label: "株式分割履歴",
-    icon: Scissors,
-  },
-  {
-    to: "/stocks",
-    label: "銘柄マスター",
-    icon: Database,
-  },
-]
 
 export function Sidebar() {
   const { isCollapsed, toggle } = useSidebarStore()

--- a/src/web/src/constants/nav.ts
+++ b/src/web/src/constants/nav.ts
@@ -1,0 +1,53 @@
+import {
+  CircleDollarSign,
+  Database,
+  FileUp,
+  History,
+  LayoutDashboard,
+  Receipt,
+  Scissors,
+  TrendingUp,
+} from "lucide-react"
+
+export const navItems = [
+  {
+    to: "/",
+    label: "ダッシュボード",
+    icon: LayoutDashboard,
+  },
+  {
+    to: "/holdings",
+    label: "保有状況",
+    icon: TrendingUp,
+  },
+  {
+    to: "/portfolio-history",
+    label: "資産推移",
+    icon: History,
+  },
+  {
+    to: "/transactions",
+    label: "取引履歴",
+    icon: Receipt,
+  },
+  {
+    to: "/transactions/import",
+    label: "CSVインポート",
+    icon: FileUp,
+  },
+  {
+    to: "/dividends",
+    label: "配当金履歴",
+    icon: CircleDollarSign,
+  },
+  {
+    to: "/stock-splits",
+    label: "株式分割履歴",
+    icon: Scissors,
+  },
+  {
+    to: "/stocks",
+    label: "銘柄マスター",
+    icon: Database,
+  },
+]


### PR DESCRIPTION
## 概要
SidebarとMobileNavで重複していた `navItems` 配列を共通定数に抽出しました。

## 変更内容
- `src/web/src/constants/nav.ts` を作成
- sidebar.tsx と mobile-nav.tsx で共通定数をインポート
- 重複コードを削減し、保守性を向上

Fixes #234

🤖 Generated with [Claude Code](https://claude.ai/code)