### PR TITLE
refactor: 日時処理の共通化

### DIFF
--- a/src/api/stock/routes/portfolio.py
+++ b/src/api/stock/routes/portfolio.py
@@ -1,7 +1,5 @@
-from datetime import datetime
 from typing import Annotated, Dict, List
 
-import pytz
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +9,7 @@ from ..schemas import PortfolioHistoryResponse, PortfolioSummary, User, WeeklyPe
 from ..services.notification_service import send_weekly_performance_notification
 from ..services.portfolio_service import PortfolioService
 from ..services.weekly_performance_service import calculate_weekly_performance, get_top_bottom_performers
+from ..utils.datetime import now_jst
 
 router = APIRouter()
 
@@ -117,8 +116,7 @@ async def notify_weekly_performance(
     )
 
     # 日本時間でタイムスタンプを生成
-    jst = pytz.timezone("Asia/Tokyo")
-    timestamp = datetime.now(jst).isoformat()
+    timestamp = now_jst().isoformat()
 
     return WeeklyPerformanceNotifyResponse(
         top_performers=top_performers,

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -1,8 +1,6 @@
 import asyncio
-from datetime import datetime, timedelta
 from typing import List
 
-import pytz
 from loguru import logger
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,6 +9,7 @@ from .. import models
 from ..models import Holding, Stock
 from ..schemas import SecurityType
 from ..services import alphavantage_service, investment_trust_service
+from ..utils.datetime import get_date_range_for_api
 from .jquants_service import get_jquants_client
 from .stooq_service import fetch_us_daily_prices_from_stooq
 
@@ -27,10 +26,7 @@ async def get_japan_stock_price(symbol: str) -> float:
     """
     try:
         # 日本時間で1週間分のデータ期間を設定
-        jst = pytz.timezone("Asia/Tokyo")
-        now = datetime.now(jst)
-        end_date = now.strftime("%Y-%m-%d")
-        start_date = (now - timedelta(days=7)).strftime("%Y-%m-%d")
+        start_date, end_date = get_date_range_for_api(days_back=7)
 
         # 非同期でJ-Quants APIを呼び出し
         prices = await get_jquants_client().get_prices(
@@ -68,15 +64,14 @@ async def get_us_stock_price(symbol: str) -> float:
             return 0.0
 
         # 1週間前の日付を取得（日本時間）
-        end = datetime.now(pytz.utc).astimezone(pytz.timezone("Asia/Tokyo"))
-        start = end - timedelta(days=7)
+        start_date, end_date = get_date_range_for_api(days_back=7)
 
         # Stooqから株価データを取得（同期I/Oをスレッド実行）
         prices = await asyncio.to_thread(
             fetch_us_daily_prices_from_stooq,
             symbol,
-            start.strftime("%Y-%m-%d"),
-            end.strftime("%Y-%m-%d"),
+            start_date,
+            end_date,
         )
 
         if prices:

--- a/src/api/stock/services/notification_service.py
+++ b/src/api/stock/services/notification_service.py
@@ -1,15 +1,14 @@
 import logging
 import os
-from datetime import datetime
 from typing import Any, Dict, Optional
 
 import httpx
-import pytz
 from dotenv import load_dotenv
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
+from ..utils.datetime import now_jst
 
 # 環境変数のロード
 load_dotenv()
@@ -51,7 +50,7 @@ class NotificationService:
                 return False
 
             # 日本時間の現在時刻
-            current_time = datetime.now(pytz.timezone("Asia/Tokyo"))
+            current_time = now_jst()
             today = current_time.strftime("%Y/%m/%d")
 
             # ポートフォリオデータのフォーマット
@@ -392,7 +391,7 @@ def _build_weekly_performance_flex_message(top_performers: list, bottom_performe
         dict: LINE Flex Message形式の辞書
     """
     # 日本時間の現在時刻
-    current_time = datetime.now(pytz.timezone("Asia/Tokyo"))
+    current_time = now_jst()
     today = current_time.strftime("%Y/%m/%d")
 
     # 上昇トップ5のコンテンツ

--- a/src/api/stock/services/weekly_performance_service.py
+++ b/src/api/stock/services/weekly_performance_service.py
@@ -4,16 +4,15 @@
 """
 
 import asyncio
-from datetime import datetime, timedelta
 from typing import List, Optional, Tuple
 
-import pytz
 from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..schemas import SecurityType, StockWeeklyPerformance
+from ..utils.datetime import get_date_range_for_api
 from .jquants_service import get_jquants_client
 from .stooq_service import fetch_us_daily_prices_from_stooq
 
@@ -30,10 +29,7 @@ async def get_japan_stock_weekly_prices(symbol: str) -> Optional[Tuple[float, fl
     """
     try:
         # 日本時間で2週間分のデータ期間を設定（営業日を確実に取得するため余裕を持つ）
-        jst = pytz.timezone("Asia/Tokyo")
-        now = datetime.now(jst)
-        end_date = now.strftime("%Y-%m-%d")
-        start_date = (now - timedelta(days=14)).strftime("%Y-%m-%d")
+        start_date, end_date = get_date_range_for_api(days_back=14)
 
         # J-Quants APIを呼び出し
         prices = await get_jquants_client().get_prices(
@@ -69,15 +65,14 @@ async def get_us_stock_weekly_prices(symbol: str) -> Optional[Tuple[float, float
     """
     try:
         # 2週間分のデータを取得（営業日を確実に取得するため余裕を持つ）
-        end = datetime.now(pytz.utc).astimezone(pytz.timezone("Asia/Tokyo"))
-        start = end - timedelta(days=14)
+        start_date, end_date = get_date_range_for_api(days_back=14)
 
         # Stooqから株価データを取得（同期I/Oをスレッド実行）
         prices = await asyncio.to_thread(
             fetch_us_daily_prices_from_stooq,
             symbol,
-            start.strftime("%Y-%m-%d"),
-            end.strftime("%Y-%m-%d"),
+            start_date,
+            end_date,
         )
 
         # 返却は古い順なので末尾が最新、6件目後ろが5営業日前

--- a/src/api/stock/utils/datetime.py
+++ b/src/api/stock/utils/datetime.py
@@ -3,7 +3,7 @@
 全APIでリクエスト/レスポンスをJST（日本標準時）で統一するための共通関数を提供します。
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -63,3 +63,31 @@ def from_jst_input(dt_input: Optional[str | datetime]) -> Optional[datetime]:
 
     # タイムゾーン情報がある場合はJSTに変換
     return dt.astimezone(JST)
+
+
+def now_jst() -> datetime:
+    """現在のJST時刻を取得する
+
+    Returns:
+        JSTタイムゾーン付きの現在時刻
+    """
+    return datetime.now(JST)
+
+
+def get_date_range_for_api(days_back: int = 7) -> tuple[str, str]:
+    """API用の日付範囲を取得（start_date, end_date）
+
+    日本時間で現在日時と指定日数前の日付範囲を文字列で返します。
+    外部APIへのリクエストで使用されることを想定しています。
+
+    Args:
+        days_back: 遡る日数（デフォルト: 7日）
+
+    Returns:
+        tuple[str, str]: (start_date, end_date) の形式で日付文字列を返す
+                         形式: "YYYY-MM-DD"
+    """
+    now = now_jst()
+    end_date = now.strftime("%Y-%m-%d")
+    start_date = (now - timedelta(days=days_back)).strftime("%Y-%m-%d")
+    return start_date, end_date

--- a/src/api/tests/test_datetime_conversion.py
+++ b/src/api/tests/test_datetime_conversion.py
@@ -7,7 +7,7 @@
 from datetime import datetime
 
 from stock.schemas import Dividend, DividendBase, Transaction, TransactionCreate
-from stock.utils.datetime import JST, UTC, from_jst_input, to_jst
+from stock.utils.datetime import JST, UTC, from_jst_input, get_date_range_for_api, now_jst, to_jst
 
 
 class TestDatetimeUtils:
@@ -188,3 +188,66 @@ class TestJSTBoundaryEdgeCases:
         assert back_to_jst.year == 2024
         assert back_to_jst.month == 1
         assert back_to_jst.day == 1
+
+
+class TestNowJst:
+    """now_jst関数のテスト"""
+
+    def test_now_jst_returns_jst_datetime(self):
+        """now_jst()がJSTタイムゾーン付きのdatetimeを返すこと"""
+        now = now_jst()
+
+        assert now.tzinfo == JST
+        # 現在時刻であることを確認（秒単位での比較は避ける）
+        assert isinstance(now, datetime)
+
+    def test_now_jst_returns_current_time(self):
+        """now_jst()が現在時刻を返すこと"""
+        now1 = now_jst()
+        now2 = now_jst()
+
+        # 2回の呼び出しの時刻差が1秒以内であること
+        diff = abs((now2 - now1).total_seconds())
+        assert diff < 1.0
+
+
+class TestGetDateRangeForApi:
+    """get_date_range_for_api関数のテスト"""
+
+    def test_get_date_range_default_7_days(self):
+        """デフォルトで7日間の日付範囲を返すこと"""
+        start_date, end_date = get_date_range_for_api()
+
+        # 日付形式が正しいことを確認
+        assert len(start_date) == 10  # YYYY-MM-DD
+        assert len(end_date) == 10
+        assert start_date[4] == "-"
+        assert start_date[7] == "-"
+        assert end_date[4] == "-"
+        assert end_date[7] == "-"
+
+        # start_dateがend_dateより前であることを確認
+        start_dt = datetime.fromisoformat(start_date)
+        end_dt = datetime.fromisoformat(end_date)
+        diff = (end_dt - start_dt).days
+        assert diff == 7
+
+    def test_get_date_range_custom_days(self):
+        """指定した日数の日付範囲を返すこと"""
+        start_date, end_date = get_date_range_for_api(days_back=14)
+
+        start_dt = datetime.fromisoformat(start_date)
+        end_dt = datetime.fromisoformat(end_date)
+        diff = (end_dt - start_dt).days
+        assert diff == 14
+
+    def test_get_date_range_format(self):
+        """YYYY-MM-DD形式で日付を返すこと"""
+        start_date, end_date = get_date_range_for_api(days_back=1)
+
+        # 正規表現で形式をチェック
+        import re
+
+        date_pattern = r"^\d{4}-\d{2}-\d{2}$"
+        assert re.match(date_pattern, start_date)
+        assert re.match(date_pattern, end_date)


### PR DESCRIPTION
## 概要

JSTタイムゾーン取得・日付計算のロジックが複数のファイルで重複していたため、utils/datetime.pyに共通関数を追加して統一しました。

## 変更内容
- utils/datetime.pyに`now_jst()`と`get_date_range_for_api()`を追加
- holding_service.py, weekly_performance_service.pyでpytzの使用を削除
- notification_service.py, portfolio.pyで共通関数を利用
- テストコードを追加 (全19件成功)

Closes #246

🤖 Generated with [Claude Code](https://claude.ai/claude-code)