### PR TITLE
DRY: 集計クエリのJST変換処理を共通化

### DIFF
--- a/src/api/stock/services/dividend_service.py
+++ b/src/api/stock/services/dividend_service.py
@@ -1,10 +1,11 @@
 from typing import List, Optional
 
-from sqlalchemy import extract, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from loguru import logger
 
 from .. import models, schemas
+from ..utils import get_jst_extract_columns
 from .holding_service import update_single_holding_pl
 from .stock_service import StockService
 
@@ -115,9 +116,7 @@ class DividendService:
         """
         # payment_date を JST に変換して月ごとに配当金を集計するクエリ
         # ※ payment_date は DB では UTC で保存されているため、JST への変換が必要
-        payment_date_jst = models.Dividend.payment_date.op("AT TIME ZONE")("Asia/Tokyo")
-        year = extract("year", payment_date_jst).label("year")
-        month = extract("month", payment_date_jst).label("month")
+        year, month = get_jst_extract_columns(models.Dividend.payment_date)
 
         query = (
             select(

--- a/src/api/stock/services/transaction_service.py
+++ b/src/api/stock/services/transaction_service.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Optional, Union
 
-from sqlalchemy import extract, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from loguru import logger
 
 from .. import models, schemas
+from ..utils import get_jst_extract_columns
 from .holding_service import (
     calculate_holding_from_transactions,
     calculate_realized_pl_from_transactions,
@@ -234,9 +235,7 @@ class TransactionService:
         """
         # 購入取引（transaction_type='buy'）のみを対象に集計
         # transaction_date を JST に変換して月ごとに集計するクエリ
-        transaction_date_jst = models.Transaction.transaction_date.op("AT TIME ZONE")("Asia/Tokyo")
-        year = extract("year", transaction_date_jst).label("year")
-        month = extract("month", transaction_date_jst).label("month")
+        year, month = get_jst_extract_columns(models.Transaction.transaction_date)
 
         query = (
             select(
@@ -298,8 +297,7 @@ class TransactionService:
         """
         # 購入取引（transaction_type='buy'）のみを対象に集計
         # transaction_date を JST に変換して年ごとに集計するクエリ
-        transaction_date_jst = models.Transaction.transaction_date.op("AT TIME ZONE")("Asia/Tokyo")
-        year = extract("year", transaction_date_jst).label("year")
+        year, _ = get_jst_extract_columns(models.Transaction.transaction_date)
 
         query = (
             select(

--- a/src/api/stock/utils/__init__.py
+++ b/src/api/stock/utils/__init__.py
@@ -1,4 +1,5 @@
 # utils パッケージ
 from .datetime import JST, UTC, from_jst_input, to_jst
+from .query_utils import get_jst_extract_columns
 
-__all__ = ["JST", "UTC", "to_jst", "from_jst_input"]
+__all__ = ["JST", "UTC", "to_jst", "from_jst_input", "get_jst_extract_columns"]

--- a/src/api/stock/utils/query_utils.py
+++ b/src/api/stock/utils/query_utils.py
@@ -1,0 +1,26 @@
+"""SQLAlchemy クエリ用のユーティリティ関数"""
+
+from sqlalchemy import ColumnElement, extract
+from sqlalchemy.sql.elements import Label
+
+
+def get_jst_extract_columns(date_column: ColumnElement) -> tuple[Label, Label]:
+    """JSTベースの年月抽出カラムを返す
+
+    データベースに保存されているUTC日時をJST（Asia/Tokyo）に変換し、
+    年と月を抽出したSQLAlchemyのラベル付きカラムを返します。
+
+    Args:
+        date_column: 日時カラム（通常はUTCで保存されている）
+
+    Returns:
+        tuple[Label, Label]: (year, month) のラベル付きカラム
+
+    Example:
+        >>> year, month = get_jst_extract_columns(models.Transaction.transaction_date)
+        >>> query = select(year, month, func.sum(...)).group_by(year, month)
+    """
+    date_jst = date_column.op("AT TIME ZONE")("Asia/Tokyo")
+    year = extract("year", date_jst).label("year")
+    month = extract("month", date_jst).label("month")
+    return year, month

--- a/src/api/tests/test_query_utils.py
+++ b/src/api/tests/test_query_utils.py
@@ -1,0 +1,38 @@
+"""query_utils のテスト"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stock.utils.query_utils import get_jst_extract_columns
+
+
+@pytest.mark.asyncio
+async def test_get_jst_extract_columns_returns_year_and_month(db_session: AsyncSession):
+    """get_jst_extract_columns が年と月のラベル付きカラムを返すこと"""
+    from stock import models
+
+    # 関数を呼び出して年月カラムを取得
+    year, month = get_jst_extract_columns(models.Transaction.transaction_date)
+
+    # ラベルが正しいことを確認
+    assert year.name == "year"
+    assert month.name == "month"
+
+
+@pytest.mark.asyncio
+async def test_get_jst_extract_columns_works_in_query(db_session: AsyncSession):
+    """get_jst_extract_columns がクエリ内で正常に動作すること"""
+    from stock import models
+
+    # 関数を使ってクエリを作成
+    year, month = get_jst_extract_columns(models.Transaction.transaction_date)
+    query = select(year, month)
+
+    # クエリが正常にコンパイルできることを確認（実行はせず構文チェックのみ）
+    compiled = query.compile()
+    compiled_str = str(compiled)
+    assert "AT TIME ZONE" in compiled_str
+    assert "EXTRACT" in compiled_str.upper()
+    # バインドパラメータに Asia/Tokyo が含まれていることを確認
+    assert "Asia/Tokyo" in str(compiled.params.values())


### PR DESCRIPTION
## 概要

集計クエリ（月次・年次トランザクション、月次配当）で重複していたJSTタイムゾーン変換と年月抽出のロジックを共通化しました。

## 変更内容

- `src/api/stock/utils/query_utils.py`: 共通関数 `get_jst_extract_columns()` を追加
- `transaction_service.py`: `get_monthly_summary()`, `get_yearly_summary()` をリファクタリング
- `dividend_service.py`: `get_monthly_dividends()` をリファクタリング
- `tests/test_query_utils.py`: ユーティリティ関数のテストを追加

## テスト

✅ 全テスト成功（14テスト）

## 影響範囲

- API仕様に変更なし
- 既存の動作を完全に維持
- 内部実装の品質向上のみ

Closes #248

🤖 Generated with [Claude Code](https://claude.ai/code)