### PR TITLE
DRY: Stock存在確認ロジックを共通化

### DIFF
--- a/src/api/stock/services/dividend_service.py
+++ b/src/api/stock/services/dividend_service.py
@@ -19,19 +19,7 @@ class DividendService:
         self, dividend: schemas.DividendCreate, user_id: int
     ) -> Optional[models.Dividend]:
         # 株式の存在確認または登録
-        stock_query = select(models.Stock).where(models.Stock.symbol == dividend.symbol)
-        stock_result = await self.db.execute(stock_query)
-        stock = stock_result.scalar_one_or_none()
-        logger.info(
-            "Stockを取得しました action=select user_id={} symbol={} found={}",
-            user_id,
-            dividend.symbol,
-            bool(stock),
-        )
-
-        if not stock:
-            stock = await self.stock_service.create_stock(schemas.StockCreate(symbol=dividend.symbol))
-            logger.info("Stockに登録しました action=create user_id={} symbol={}", user_id, dividend.symbol)
+        await self.stock_service.get_or_create_stock(dividend.symbol, user_id)
 
         # 配当情報の登録
         db_dividend = models.Dividend(**dividend.model_dump(), user_id=user_id)

--- a/src/api/stock/services/stock_service.py
+++ b/src/api/stock/services/stock_service.py
@@ -21,6 +21,30 @@ class StockService:
     def __init__(self, db: AsyncSession):
         self.db = db
 
+    async def get_or_create_stock(self, symbol: str, user_id: Optional[int] = None) -> models.Stock:
+        """
+        Stockを取得または作成する
+        - 既存の場合: 登録済みのStockを返す
+        - 未登録の場合: 新規作成して返す
+        """
+        query = select(models.Stock).where(models.Stock.symbol == symbol)
+        result = await self.db.execute(query)
+        stock = result.scalar_one_or_none()
+
+        user_info = f"user_id={user_id} " if user_id is not None else ""
+        logger.info(
+            "Stockを取得しました action=select {}symbol={} found={}",
+            user_info,
+            symbol,
+            bool(stock),
+        )
+
+        if not stock:
+            stock = await self.create_stock(schemas.StockCreate(symbol=symbol))
+            logger.info("Stockに登録しました action=create {}symbol={}", user_info, symbol)
+
+        return stock
+
     async def create_stock(self, stock: schemas.StockCreate) -> models.Stock:
         """
         新規銘柄を登録する

--- a/src/api/stock/services/transaction_service.py
+++ b/src/api/stock/services/transaction_service.py
@@ -24,19 +24,7 @@ class TransactionService:
         self, transaction: schemas.TransactionCreate, user_id: int
     ) -> Optional[models.Transaction]:
         # 株式の存在確認または登録
-        stock_query = select(models.Stock).where(models.Stock.symbol == transaction.symbol)
-        stock_result = await self.db.execute(stock_query)
-        stock = stock_result.scalar_one_or_none()
-        logger.info(
-            "Stockを取得しました action=select user_id={} symbol={} found={}",
-            user_id,
-            transaction.symbol,
-            bool(stock),
-        )
-
-        if not stock:
-            stock = await self.stock_service.create_stock(schemas.StockCreate(symbol=transaction.symbol))
-            logger.info("Stockに登録しました action=create user_id={} symbol={}", user_id, transaction.symbol)
+        await self.stock_service.get_or_create_stock(transaction.symbol, user_id)
 
         # 保有情報の取得
         holding_query = select(models.Holding).where(


### PR DESCRIPTION
## 概要

Stock存在確認ロジックを共通化しました。

## 変更内容

- StockService.get_or_create_stock() メソッドを追加
- transaction_service.pyの重複ロジック(26-38行目)を共通メソッドに置き換え
- dividend_service.pyの重複ロジック(21-33行目)を共通メソッドに置き換え

## 効果

- 重複コード削減: 約26行削減
- 保守性向上: Stock作成ロジックが1箇所に集約
- テスト結果: 全105テスト成功

Fixes #249

🤖 Generated with [Claude Code](https://claude.ai/code)