### PR TITLE
fix: 外貨建てCSVの日付パースのデグレを修正

### DIFF
--- a/src/api/stock/services/csv_import_service.py
+++ b/src/api/stock/services/csv_import_service.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import pandas as pd
 from loguru import logger
 
-from .csv_utils import date_key, decode_csv_content, get_fund_symbol, is_empty, to_number
+from .csv_utils import date_key, decode_csv_content, get_fund_symbol, is_empty, parse_date, to_number
 
 
 @dataclass
@@ -184,8 +184,8 @@ def parse_csv_content(content: bytes) -> tuple[list[ParsedTransaction], list[str
         )
     )
 
-    # 日付の変換（YYYY/MM/DD形式のみサポート）
-    df_raw["約定日"] = pd.to_datetime(df_raw["約定日"], format="%Y/%m/%d").dt.strftime("%Y/%m/%d")
+    # 日付の変換
+    df_raw["約定日"] = df_raw["約定日"].apply(parse_date)
 
     # 必要なカラムのみ抽出
     sbi_data = df_raw[

--- a/src/api/stock/services/csv_utils.py
+++ b/src/api/stock/services/csv_utils.py
@@ -51,6 +51,21 @@ def get_fund_symbol(fund_name: str) -> str | None:
     return NORMALIZED_FUND_MAP.get(key)
 
 
+def parse_date(val) -> str | None:
+    """日付文字列をYYYY/MM/DD形式に変換
+
+    SBI証券CSVの複数日付形式に対応する。
+    - YYYY年MM月DD日 形式（外貨建てCSV）
+    - YYYY/MM/DD 形式（円建てCSV）
+    """
+    if is_empty(val):
+        return None
+    val_str = str(val).strip()
+    if "年" in val_str:
+        return pd.to_datetime(val_str, format="%Y年%m月%d日").strftime("%Y/%m/%d")
+    return pd.to_datetime(val_str, format="%Y/%m/%d").strftime("%Y/%m/%d")
+
+
 def decode_csv_content(content: bytes) -> list[str]:
     """CSVバイト列をデコードして行リストを返す
 

--- a/src/api/tests/api/test_csv_import.py
+++ b/src/api/tests/api/test_csv_import.py
@@ -33,9 +33,9 @@ class TestParseCsvContent:
         assert tx.tax == 0.0
 
     def test_parse_foreign_csv(self):
-        """外貨建てCSVのパーステスト"""
+        """外貨建てCSVのパーステスト（実際のSBI証券フォーマット: YYYY年MM月DD日形式）"""
         csv_content = """国内約定日,通貨,銘柄名,取引,預り区分,約定数量,約定単価,国内受渡日,受渡金額
-2024/01/30,日本円,テスト株式 TEST / NASDAQ,買付,NISA,10,100,2024/02/01,15000"""
+"2024年01月30日",日本円,テスト株式 TEST / NASDAQ,買付,NISA,10,100,24/02/01,15000"""
 
         transactions, errors = parse_csv_content(csv_content.encode("utf-8"))
 


### PR DESCRIPTION
リファクタリング(a1d7362)でparse_date関数が削除され、YYYY/MM/DD形式のみ サポートに退化していた。外貨建てCSVの約定日はYYYY年MM月DD日形式のため
インポートがエラーになっていた。

- csv_utils.pyにparse_date関数を復元（YYYY年MM月DD日・YYYY/MM/DD対応）
- csv_import_service.pyでparse_dateを使うよう修正
- test_csv_import.pyの外貨建てテストデータを実際のSBI証券フォーマットに修正