### PR TITLE
fix: 外貨建てCSVの差分検出でUSD単価を比較キーに使うよう修正

### DIFF
--- a/src/api/stock/services/csv_import_service.py
+++ b/src/api/stock/services/csv_import_service.py
@@ -33,13 +33,18 @@ class ParsedTransaction:
     def __key(self):
         """差分検出用のハッシュキー"""
         trade_date = date_key(self.transaction_date)
+        # 外貨建て（usd_priceあり）の場合はUSD単価で比較する。
+        # 円建てpriceは受渡金額/数量で計算されるためエクスポート時の為替レートに依存し変動する。
+        price_key = (
+            round(float(self.usd_price), 4) if self.usd_price is not None else round(float(self.price), 2)
+        )
         return (
             self.symbol,
             self.transaction_type,
             trade_date,
             self.account_type,
             round(float(self.quantity), 4),
-            round(float(self.price), 2),
+            price_key,
         )
 
     def __hash__(self):
@@ -302,6 +307,7 @@ def detect_new_transactions(
     # 差分を計算
     parsed_set = set(parsed_transactions)
     diff_set = parsed_set - existing_set
+
     # UI側でのプレビュー順が毎回変わらないよう、日付等で順序を安定化
     new_transactions = sorted(
         diff_set,

--- a/src/api/tests/api/test_csv_import.py
+++ b/src/api/tests/api/test_csv_import.py
@@ -54,7 +54,7 @@ class TestParseCsvContent:
         csv_content = """約定日,銘柄,銘柄コード,市場,取引,預り,課税,約定数量,約定単価,手数料/諸経費等,税額,受渡日,受渡金額/決済損益
 2024/01/30,eMAXIS Slim 全世界株式(オール・カントリー),--,--,投信金額買付,NISA(つ),--,50000,20000,0,0,2024/02/01,100000000"""
 
-        transactions, errors = parse_csv_content(csv_content.encode("utf-8"))
+        transactions, _ = parse_csv_content(csv_content.encode("utf-8"))
 
         assert len(transactions) == 1
         tx = transactions[0]
@@ -137,7 +137,7 @@ class TestDetectNewTransactions:
                 self.tax = tax
                 self.transaction_date = transaction_date
 
-            def _create_enum(self, enum_class, value):
+            def _create_enum(self, _enum_class, value):
                 class EnumValue:
                     def __init__(self, v):
                         self.value = v
@@ -171,4 +171,69 @@ class TestDetectNewTransactions:
 
         new_transactions = detect_new_transactions(parsed, existing)
 
+        assert len(new_transactions) == 0
+
+    def test_foreign_price_change_not_detected_as_new(self):
+        """外貨建て取引で円建てpriceが変わっても登録済みと判断されるテスト
+
+        外貨建てCSVの円建てprice（受渡金額/数量）はエクスポートごとに変わるため、
+        usd_priceが同じなら同一取引として判断する必要がある。
+        """
+        # 最初のエクスポートでインポートした取引（円建てprice=73063.0）
+        parsed = [
+            ParsedTransaction(
+                symbol="MSFT",
+                name="マイクロソフト",
+                transaction_type="買付",
+                quantity=1.0,
+                price=73063.0,  # 新しいエクスポートでは為替が変わり別の値になる
+                usd_price=477.535,
+                account_type="NISA(成長投資枠)",
+                fee=0.0,
+                tax=0.0,
+                transaction_date=datetime(2026, 1, 28),
+            ),
+        ]
+
+        class MockTransaction:
+            def __init__(
+                self,
+                symbol,
+                transaction_type,
+                quantity,
+                price,
+                usd_price,
+                account_type,
+                fee,
+                tax,
+                transaction_date,
+            ):
+                self.symbol = symbol
+                self.transaction_type = transaction_type  # 文字列で渡す（DBの実際の返り値を模倣）
+                self.quantity = quantity
+                self.price = price
+                self.usd_price = usd_price
+                self.account_type = account_type
+                self.fee = fee
+                self.tax = tax
+                self.transaction_date = transaction_date
+
+        # DBには以前の為替レートで計算されたprice（72000.0）で保存済み
+        existing = [
+            MockTransaction(
+                symbol="MSFT",
+                transaction_type="buy",
+                quantity=1.0,
+                price=72000.0,  # 以前のエクスポートで登録された価格（為替レートが違う）
+                usd_price=477.535,  # USD単価は変わらない
+                account_type="NISA(成長投資枠)",
+                fee=0.0,
+                tax=0.0,
+                transaction_date=datetime(2026, 1, 28),
+            )
+        ]
+
+        new_transactions = detect_new_transactions(parsed, existing)
+
+        # USD単価が同じなので登録済みと判断され、差分なし
         assert len(new_transactions) == 0


### PR DESCRIPTION
外貨建てCSVの円建てprice（受渡金額/数量）はSBI証券がエクスポート時の
為替レートで算出するため、同じ約定でもエクスポートごとに値が変わる。
このため、円建てpriceを比較キーにすると登録済み取引が未登録として
誤検出される問題があった。

usd_price（USD約定単価）は約定ごとに固定値のため、外貨建て取引は
usd_priceを差分検出の比較キーとして使用するよう修正した。