### PR TITLE
feat: 保有状況テーブルのデフォルト並び順を評価額順に変更

### DIFF
--- a/src/web/src/components/dashboard/holdings-table.tsx
+++ b/src/web/src/components/dashboard/holdings-table.tsx
@@ -14,7 +14,7 @@ type SortKey = "symbol" | "quantity" | "current_price" | "market_value" | "total
 
 export function HoldingsTable({ holdings, isLoading }: HoldingsTableProps) {
   const { sortKey, sortDirection, handleSort, getSortIcon } = useTableSort<SortKey>({
-    defaultSortKey: "total_pl_percentage",
+    defaultSortKey: "market_value",
     defaultSortDirection: "desc",
   })
 


### PR DESCRIPTION
損益%（total_pl_percentage）→ 評価額（market_value）の降順に変更

https://claude.ai/code/session_016eScnngmRCvAja2cPcXxMb