### PR TITLE
Round NISA account values in limit gauge display

### DIFF
--- a/src/web/src/components/dashboard/nisa-limit-gauge.tsx
+++ b/src/web/src/components/dashboard/nisa-limit-gauge.tsx
@@ -67,13 +67,13 @@ export function NisaLimitGauge({ data, isLoading }: NisaLimitGaugeProps) {
       </CardHeader>
       <CardContent className="space-y-6">
         <Progress
-          value={yearlyTotals.NISAGrowth}
+          value={Math.round(yearlyTotals.NISAGrowth)}
           max={NISA_LIMITS.NISAGrowth}
           label={ACCOUNT_LABELS.NISAGrowth}
           colorClass="bg-green-600"
         />
         <Progress
-          value={yearlyTotals.NISAAccumulation}
+          value={Math.round(yearlyTotals.NISAAccumulation)}
           max={NISA_LIMITS.NISAAccumulation}
           label={ACCOUNT_LABELS.NISAAccumulation}
           colorClass="bg-teal-600"


### PR DESCRIPTION
## Summary
Updated the NISA Limit Gauge component to round yearly total values before displaying them in progress indicators, ensuring cleaner presentation of account balance information.

## Key Changes
- Added `Math.round()` to `yearlyTotals.NISAGrowth` value passed to Progress component
- Added `Math.round()` to `yearlyTotals.NISAAccumulation` value passed to Progress component

## Implementation Details
The rounding is applied at the presentation layer when passing values to the Progress component, which prevents decimal values from being displayed in the gauge visualization while maintaining the original precision in the underlying data.

https://claude.ai/code/session_01H45u9yzpVzS4upAhdC4KFA