### PR TITLE
feat(web): 証券種別チャートに通貨別表示トグルを追加

### DIFF
--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -149,7 +149,9 @@ export function SecurityTypeChart({ data, isLoading }: SecurityTypeChartProps) {
                 cx="50%"
                 cy="50%"
                 labelLine={false}
-                label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
+                label={({ name, percent, value }) =>
+                  `${name} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
+                }
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"


### PR DESCRIPTION
## Summary
- 保有状況ページの種別パイチャートに「種別」「通貨」トグルボタンを追加
- 通貨モードでは、各銘柄の`currency`フィールドを元に円建て・ドル建ての資産比率を円グラフで表示
- 既存の種別表示はそのまま維持（デフォルト表示）

## 備考
- 投資信託（FUND）は現在バックエンドで`JPY`として登録されているため、通貨別表示でも円建てとして集計される
- オルカン等の実質ドル建て投信の分類は、バックエンド側の通貨判定ロジック修正で別途対応予定

## Test plan
- [x] `pnpm check` 通過（lint/format/typecheck/knip）
- [x] `pnpm test` 全104テスト通過
- [ ] 保有状況ページで「種別」「通貨」トグルが表示されることを確認
- [ ] トグル切り替えで円グラフが正しく切り替わることを確認

https://claude.ai/code/session_01U8XonCWB1KnpZWXXhqEPvC