### PR TITLE
refactor(web): 種別/通貨チャートのコード整理

### DIFF
--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -12,162 +12,101 @@ interface SecurityTypeChartProps {
   isLoading: boolean
 }
 
-const SECURITY_TYPE_COLORS: Record<string, string> = {
-  STOCK: "#2196F3",
-  ETF: "#FF9800",
-  REIT: "#9C27B0",
-  FUND: "#4CAF50",
+const VIEW_CONFIG: Record<
+  ViewMode,
+  {
+    label: string
+    title: string
+    getKey: (h: Holding) => string
+    colors: Record<string, string>
+    labels: Record<string, string>
+  }
+> = {
+  securityType: {
+    label: "種別",
+    title: "種別保有割合",
+    getKey: (h) => h.security_type || "UNKNOWN",
+    colors: { STOCK: "#2196F3", ETF: "#FF9800", REIT: "#9C27B0", FUND: "#4CAF50" },
+    labels: { STOCK: "株式", ETF: "ETF", REIT: "REIT", FUND: "投資信託" },
+  },
+  currency: {
+    label: "通貨",
+    title: "通貨別保有割合",
+    getKey: (h) => h.currency || "UNKNOWN",
+    colors: { JPY: "#2196F3", USD: "#FF9800" },
+    labels: { JPY: "円建て", USD: "ドル建て" },
+  },
 }
 
-const SECURITY_TYPE_LABELS: Record<string, string> = {
-  STOCK: "株式",
-  ETF: "ETF",
-  REIT: "REIT",
-  FUND: "投資信託",
-}
-
-const CURRENCY_COLORS: Record<string, string> = {
-  JPY: "#2196F3",
-  USD: "#FF9800",
-}
-
-const CURRENCY_LABELS: Record<string, string> = {
-  JPY: "円建て",
-  USD: "ドル建て",
-}
-
-const VIEW_OPTIONS: { value: ViewMode; label: string }[] = [
-  { value: "securityType", label: "種別" },
-  { value: "currency", label: "通貨" },
-]
+const VIEW_MODES: ViewMode[] = ["securityType", "currency"]
 
 export function SecurityTypeChart({ data, isLoading }: SecurityTypeChartProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("securityType")
+  const config = VIEW_CONFIG[viewMode]
 
   const chartData = useMemo(() => {
     if (!data || data.length === 0) return []
 
-    if (viewMode === "currency") {
-      const grouped = data.reduce(
-        (acc, holding) => {
-          const currency = holding.currency || "UNKNOWN"
-          const marketValue = holding.market_value ?? 0
-          acc[currency] = (acc[currency] || 0) + marketValue
-          return acc
-        },
-        {} as Record<string, number>
-      )
-
-      return Object.entries(grouped)
-        .map(([type, value]) => ({
-          name: CURRENCY_LABELS[type] || type,
-          value,
-          type,
-        }))
-        .filter((item) => item.value > 0)
-        .sort((a, b) => b.value - a.value)
+    const grouped: Record<string, number> = {}
+    for (const holding of data) {
+      const key = config.getKey(holding)
+      grouped[key] = (grouped[key] || 0) + (holding.market_value ?? 0)
     }
 
-    const grouped = data.reduce(
-      (acc, holding) => {
-        const securityType = holding.security_type || "UNKNOWN"
-        const marketValue = holding.market_value ?? 0
-        acc[securityType] = (acc[securityType] || 0) + marketValue
-        return acc
-      },
-      {} as Record<string, number>
-    )
-
     return Object.entries(grouped)
-      .map(([type, value]) => ({
-        name: SECURITY_TYPE_LABELS[type] || type,
-        value,
-        type,
-      }))
+      .map(([type, value]) => ({ name: config.labels[type] || type, value, type }))
       .filter((item) => item.value > 0)
       .sort((a, b) => b.value - a.value)
-  }, [data, viewMode])
-
-  const title = viewMode === "currency" ? "通貨別保有割合" : "種別保有割合"
-  const colorMap = viewMode === "currency" ? CURRENCY_COLORS : SECURITY_TYPE_COLORS
-
-  const toggleButtons = (
-    <div className="flex gap-1">
-      {VIEW_OPTIONS.map((option) => (
-        <Button
-          key={option.value}
-          variant={viewMode === option.value ? "default" : "outline"}
-          size="sm"
-          onClick={() => setViewMode(option.value)}
-        >
-          {option.label}
-        </Button>
-      ))}
-    </div>
-  )
-
-  if (isLoading) {
-    return (
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>{title}</CardTitle>
-          {toggleButtons}
-        </CardHeader>
-        <CardContent>
-          <div className="h-64 animate-pulse rounded bg-muted" />
-        </CardContent>
-      </Card>
-    )
-  }
-
-  if (!chartData.length) {
-    return (
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle>{title}</CardTitle>
-          {toggleButtons}
-        </CardHeader>
-        <CardContent>
-          <div className="flex h-64 items-center justify-center text-muted-foreground">No data available</div>
-        </CardContent>
-      </Card>
-    )
-  }
+  }, [data, config])
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>{title}</CardTitle>
-        {toggleButtons}
+        <CardTitle>{config.title}</CardTitle>
+        <div className="flex gap-1">
+          {VIEW_MODES.map((mode) => (
+            <Button
+              key={mode}
+              variant={viewMode === mode ? "default" : "outline"}
+              size="sm"
+              onClick={() => setViewMode(mode)}
+            >
+              {VIEW_CONFIG[mode].label}
+            </Button>
+          ))}
+        </div>
       </CardHeader>
       <CardContent>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={chartData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ name, percent, value }) =>
-                  `${name} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
-                }
-                outerRadius={80}
-                fill="#8884d8"
-                dataKey="value"
-              >
-                {chartData.map((entry) => (
-                  <Cell key={`cell-${entry.type}`} fill={colorMap[entry.type] || "#9E9E9E"} />
-                ))}
-              </Pie>
-              <Tooltip
-                formatter={(value) => formatCurrency(typeof value === "number" ? value : 0)}
-                labelFormatter={(label) => `${label}`}
-              />
-              <Legend />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
+        {isLoading ? (
+          <div className="h-64 animate-pulse rounded bg-muted" />
+        ) : !chartData.length ? (
+          <div className="flex h-64 items-center justify-center text-muted-foreground">No data available</div>
+        ) : (
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={({ name, percent, value }) =>
+                    `${name} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
+                  }
+                  outerRadius={80}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {chartData.map((entry) => (
+                    <Cell key={`cell-${entry.type}`} fill={config.colors[entry.type] || "#9E9E9E"} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(value) => formatCurrency(typeof value === "number" ? value : 0)} />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
- 重複していたreduce集計ロジックをVIEW_CONFIGで統合
- Card構造の3重繰り返しを条件分岐で1つに集約
- 不要なlabelFormatterを削除

https://claude.ai/code/session_01U8XonCWB1KnpZWXXhqEPvC