### PR TITLE
feat(api): 週次騰落率LINE通知に変動理由テキストを追加

### DIFF
--- a/src/api/stock/services/change_reason_service.py
+++ b/src/api/stock/services/change_reason_service.py
@@ -1,9 +1,10 @@
 """週次騰落率ランキングの「変動理由」を OpenAI gpt-5.4 + web 検索で生成する。
 
-LINE 週次騰落率通知の Flex Message に続けて送るテキスト本文を生成するサービス。
+LINE 週次騰落率通知の Flex Message に差し込むセクション別テキストを生成するサービス。
 """
 
 import re
+from dataclasses import dataclass
 
 from loguru import logger
 
@@ -13,8 +14,13 @@ from .classification_service import get_openai_client
 
 OPENAI_MODEL: str = "gpt-5.4"
 REASONING_EFFORT: str = "medium"
-MAX_OUTPUT_CHARS: int = 1000
+MAX_OVERVIEW_CHARS: int = 400
+MAX_SECTION_CHARS: int = 450
 REQUEST_TIMEOUT_SEC: float = 300.0
+
+MARKER_MARKET = "===市場概況==="
+MARKER_TOP = "===上昇解説==="
+MARKER_BOTTOM = "===下落解説==="
 
 CHANGE_REASON_SYSTEM_PROMPT: str = (
     "あなたは個人投資家のパートナーとして、週次の騰落率ランキングを語るお姉さんキャラクターです。\n\n"
@@ -24,20 +30,24 @@ CHANGE_REASON_SYSTEM_PROMPT: str = (
     "- 敬語は使わず、落ち着いたタメ口で、年上の余裕を感じさせる距離感で綴る。\n"
     "- 有能で、知識と判断力で信頼させるタイプ。焦らず、動じない。\n"
     "- からかい・いじりはごく軽く一文に留め、本筋は相場解説。市況の話では寄り添う姿勢を優先する。\n\n"
+    "# 出力フォーマット（厳守）\n"
+    "必ず次の3セクション構造のみで返すこと。セクションマーカーは固定文字列で変更しない。"
+    "各セクションは散文（箇条書き・見出し・銘柄を主語にした短文の列挙は禁止）。"
+    "セクションマーカー以外の見出し・ラベル・囲み記号は一切出力しない。\n\n"
+    f"{MARKER_MARKET}\n"
+    "（その週のマーケット全体の地合い。日経平均の動き、主要セクターの強弱、マクロ要因。"
+    "ポートフォリオがそれをどう反映しているかも軽く位置づける。400文字以内。）\n\n"
+    f"{MARKER_TOP}\n"
+    "（上昇ランキングの主役格を具体的な材料──決算の数値、ガイダンス、格上げ、M&A、規制、ショック等──"
+    "とともに描き、同じテーマ・セクターで連動した銘柄はまとめて束ねて触れる。450文字以内。）\n\n"
+    f"{MARKER_BOTTOM}\n"
+    "（下落ランキングも同様に、筆頭の理由を描いたうえで、似た材料・テーマで沈んだ銘柄は束ねて触れる。"
+    "可能なら「ファンダ悪化ではなくテーマローテーション」のような解釈の補助線も添える。450文字以内。）\n\n"
     "# 書き方の指針\n"
     "入力される「週間騰落率ランキング」（上位5銘柄・下位5銘柄、日本株と米国株が混在）について、"
-    "直近1週間の値動きの主因をweb検索で調査し、一人の語り手として綴ってください。\n"
-    "- 全体を2〜3段落の物語として構成する。箇条書き、銘柄ごとの見出し、銘柄を主語にした短文の列挙は禁止。\n"
-    "- 冒頭の段落で、その週のマーケット全体の地合い（日経平均の動き、主要セクターの強弱、マクロ要因）を踏まえつつ、"
-    "ポートフォリオがそれをどう反映しているかを軽く位置づける。\n"
-    "- 続く段落で、上昇側の主役格を具体的な材料（決算の数値、ガイダンス、格上げ、M&A、規制、ショック等）"
-    "とともに描き、同じテーマ・セクターで連動した銘柄はまとめて束ねて触れる。"
-    "「銘柄名＋は＋〜しました。」を連発する硬いテロップ調は絶対に避ける。\n"
-    "- 下落側も同様に、筆頭の理由を描いたうえで、似た材料・テーマで沈んだ銘柄は束ねて触れる。\n"
-    "- 可能な範囲で「これはファンダ悪化じゃなくてテーマローテーションね」のような、"
-    "ランキングの意味づけや解釈の補助線を添える。\n\n"
+    "直近1週間の値動きの主因をweb検索で調査し、一人の語り手として綴ってください。"
+    "「銘柄名＋は＋〜しました。」を連発する硬いテロップ調は絶対に避ける。\n\n"
     "# 厳守事項\n"
-    "- 全体で1000文字以内（厳守）。\n"
     "- 銘柄の識別は銘柄名のみ。ティッカーや証券コードは出力しない。\n"
     "- 出典URL、Markdown形式のリンク、参照サイト名の併記（例: diamond.jp, Nikkei, Yahoo!ファイナンス 等）、"
     "引用マーク、脚注、参考情報欄は一切出力しない。情報源は本文中に混ぜず、事実だけを自分の言葉で書く。\n"
@@ -52,6 +62,15 @@ _MD_LINK = re.compile(r"\[[^\]]*\]\([^)]*\)")
 _BARE_URL = re.compile(r"https?://\S+")
 _MULTI_SPACE = re.compile(r"[ \t]{2,}")
 _MULTI_NEWLINE = re.compile(r"\n{3,}")
+
+
+@dataclass(frozen=True)
+class ChangeReasonSections:
+    """変動理由を3セクションに分けて保持する。"""
+
+    market_overview: str
+    top_commentary: str
+    bottom_commentary: str
 
 
 def _strip_citations(text: str) -> str:
@@ -80,11 +99,11 @@ def _format_performers_for_prompt(
         f"【上昇トップ】\n{top_block}\n\n"
         f"【下落ワースト】\n{bottom_block}\n\n"
         "これらの銘柄について、直近1週間の値動きの主因をweb検索で調査し、"
-        "システム指示に従い段落形式の散文で1000文字以内にまとめてください。"
+        "システム指示のセクション構造を厳守して返してください。"
     )
 
 
-def _trim_to_max_chars(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
+def _trim_to_max_chars(text: str, max_chars: int) -> str:
     if len(text) <= max_chars:
         return text
 
@@ -97,18 +116,43 @@ def _trim_to_max_chars(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
     return truncated + "…"
 
 
+def _parse_sections(text: str) -> ChangeReasonSections | None:
+    """マーカー区切りテキストを3セクションに分解する。"""
+    idx_market = text.find(MARKER_MARKET)
+    idx_top = text.find(MARKER_TOP)
+    idx_bottom = text.find(MARKER_BOTTOM)
+    if idx_market == -1 or idx_top == -1 or idx_bottom == -1:
+        return None
+    if not (idx_market < idx_top < idx_bottom):
+        return None
+
+    market = text[idx_market + len(MARKER_MARKET) : idx_top].strip()
+    top = text[idx_top + len(MARKER_TOP) : idx_bottom].strip()
+    bottom = text[idx_bottom + len(MARKER_BOTTOM) :].strip()
+
+    if not market or not top or not bottom:
+        return None
+
+    return ChangeReasonSections(
+        market_overview=_trim_to_max_chars(market, MAX_OVERVIEW_CHARS),
+        top_commentary=_trim_to_max_chars(top, MAX_SECTION_CHARS),
+        bottom_commentary=_trim_to_max_chars(bottom, MAX_SECTION_CHARS),
+    )
+
+
 async def generate_change_reasons(
     top_performers: list[StockWeeklyPerformance],
     bottom_performers: list[StockWeeklyPerformance],
-) -> str | None:
-    """騰落銘柄リストから変動理由テキストを生成する。
+) -> ChangeReasonSections | None:
+    """騰落銘柄リストから変動理由セクションを生成する。
 
     Args:
         top_performers: 上昇トップ銘柄のリスト
         bottom_performers: 下落ワースト銘柄のリスト
 
     Returns:
-        1000文字以内の日本語テキスト。API未設定・失敗・空レスポンス時は None。
+        3セクション（市場概況・上昇解説・下落解説）。
+        API未設定・失敗・空レスポンス・パース失敗時は None。
     """
     if not settings.OPENAI_API_KEY:
         logger.warning("OPENAI_API_KEYが未設定のため変動理由生成をスキップします action=external_io")
@@ -141,9 +185,17 @@ async def generate_change_reasons(
             logger.warning("OpenAIレスポンスの本文が空でした action=external_io")
             return None
         cleaned = _strip_citations(text)
-        trimmed = _trim_to_max_chars(cleaned)
-        logger.info("変動理由生成完了 action=external_io length={}", len(trimmed))
-        return trimmed
+        sections = _parse_sections(cleaned)
+        if not sections:
+            logger.warning("変動理由のセクション分解に失敗 action=external_io")
+            return None
+        logger.info(
+            "変動理由生成完了 action=external_io overview={} top={} bottom={}",
+            len(sections.market_overview),
+            len(sections.top_commentary),
+            len(sections.bottom_commentary),
+        )
+        return sections
     except Exception:
         logger.exception("変動理由生成失敗 action=external_io")
         return None

--- a/src/api/stock/services/change_reason_service.py
+++ b/src/api/stock/services/change_reason_service.py
@@ -39,8 +39,6 @@ def _format_performers_for_prompt(
     top_performers: list[StockWeeklyPerformance],
     bottom_performers: list[StockWeeklyPerformance],
 ) -> str:
-    """OpenAI への入力として、上位・下位銘柄のリストを文字列化する。"""
-
     def _format_line(rank: int, p: StockWeeklyPerformance) -> str:
         sign = "+" if p.change_rate >= 0 else ""
         return f"{rank}. {p.name}（{p.symbol}）: {sign}{p.change_rate:.2f}%"
@@ -58,7 +56,6 @@ def _format_performers_for_prompt(
 
 
 def _trim_to_max_chars(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
-    """指定文字数を超えたら句点または改行で切り詰め、末尾に「…」を付加する。"""
     if len(text) <= max_chars:
         return text
 

--- a/src/api/stock/services/change_reason_service.py
+++ b/src/api/stock/services/change_reason_service.py
@@ -3,6 +3,8 @@
 LINE 週次騰落率通知の Flex Message に続けて送るテキスト本文を生成するサービス。
 """
 
+import re
+
 from loguru import logger
 
 from ..database import settings
@@ -10,29 +12,56 @@ from ..schemas import StockWeeklyPerformance
 from .classification_service import get_openai_client
 
 OPENAI_MODEL: str = "gpt-5.4"
-REASONING_EFFORT: str = "high"
+REASONING_EFFORT: str = "medium"
 MAX_OUTPUT_CHARS: int = 1000
-REQUEST_TIMEOUT_SEC: float = 180.0
+REQUEST_TIMEOUT_SEC: float = 300.0
 
 CHANGE_REASON_SYSTEM_PROMPT: str = (
-    "あなたは日本の個人投資家向けの株式市況アナリストです。"
-    "入力された「週間騰落率ランキング」（上位5銘柄・下位5銘柄、最大10銘柄、日本株と米国株が混在）について、"
-    "直近1週間の値動きの主因をweb検索で調査し、日本語でまとめてください。\n\n"
-    "必須の遵守事項:\n"
-    "- 全体で1000文字以内（厳守）。超えそうなら銘柄を統合して要約すること。\n"
-    "- 同じセクターで連れ高・連れ安した銘柄、個別材料が乏しい銘柄はまとめて1行で記述してよい。"
-    "例: 「AAAA・BBBBは半導体セクターの連れ高」\n"
-    "- 個別に明確な材料（決算・ガイダンス・M&A・アナリスト格上げ/格下げ・規制・ショック等）がある銘柄は"
-    "銘柄ごとに1〜2文で説明。\n"
-    "- 銘柄の識別は「銘柄名」のみ。銘柄コード（ティッカー/証券コード）は冗長なので出力に含めない。\n"
-    "- 絵文字・記号による装飾は使わない。文字数節約のためプレーンな日本語テキストのみ。\n"
-    "- 出典URLや引用マーク、脚注は出力に含めない。\n"
-    "- web検索で確実な情報が見つからない銘柄は推測せず"
-    "「特段の材料は確認できず（地合いの影響と思われる）」と簡潔に記載する。\n"
-    "- 冗長な前置き・まとめの挨拶・免責事項は入れない。本文のみ。\n"
-    "- 構成: 最初に「上昇トップ」セクション、次に「下落ワースト」セクション。"
-    "各セクションは銘柄（またはまとめたグループ）ごとに改行。"
+    "あなたは個人投資家のパートナーとして、週次の騰落率ランキングを語るお姉さんキャラクターです。\n\n"
+    "# キャラクター設定\n"
+    "- 一人称は「私」、相手のことは「君」または「あなた」。\n"
+    "- 語尾に「〜よ」「〜わね」「〜かしら」「〜じゃない」を自然に混ぜる。多用はしない。\n"
+    "- 敬語は使わず、落ち着いたタメ口で、年上の余裕を感じさせる距離感で綴る。\n"
+    "- 有能で、知識と判断力で信頼させるタイプ。焦らず、動じない。\n"
+    "- からかい・いじりはごく軽く一文に留め、本筋は相場解説。市況の話では寄り添う姿勢を優先する。\n\n"
+    "# 書き方の指針\n"
+    "入力される「週間騰落率ランキング」（上位5銘柄・下位5銘柄、日本株と米国株が混在）について、"
+    "直近1週間の値動きの主因をweb検索で調査し、一人の語り手として綴ってください。\n"
+    "- 全体を2〜3段落の物語として構成する。箇条書き、銘柄ごとの見出し、銘柄を主語にした短文の列挙は禁止。\n"
+    "- 冒頭の段落で、その週のマーケット全体の地合い（日経平均の動き、主要セクターの強弱、マクロ要因）を踏まえつつ、"
+    "ポートフォリオがそれをどう反映しているかを軽く位置づける。\n"
+    "- 続く段落で、上昇側の主役格を具体的な材料（決算の数値、ガイダンス、格上げ、M&A、規制、ショック等）"
+    "とともに描き、同じテーマ・セクターで連動した銘柄はまとめて束ねて触れる。"
+    "「銘柄名＋は＋〜しました。」を連発する硬いテロップ調は絶対に避ける。\n"
+    "- 下落側も同様に、筆頭の理由を描いたうえで、似た材料・テーマで沈んだ銘柄は束ねて触れる。\n"
+    "- 可能な範囲で「これはファンダ悪化じゃなくてテーマローテーションね」のような、"
+    "ランキングの意味づけや解釈の補助線を添える。\n\n"
+    "# 厳守事項\n"
+    "- 全体で1000文字以内（厳守）。\n"
+    "- 銘柄の識別は銘柄名のみ。ティッカーや証券コードは出力しない。\n"
+    "- 出典URL、Markdown形式のリンク、参照サイト名の併記（例: diamond.jp, Nikkei, Yahoo!ファイナンス 等）、"
+    "引用マーク、脚注、参考情報欄は一切出力しない。情報源は本文中に混ぜず、事実だけを自分の言葉で書く。\n"
+    "- 絵文字や記号による装飾は使わない。プレーンな日本語テキストのみ。\n"
+    "- 前置き・挨拶・まとめ・免責事項は一切不要。本文のみ。\n"
+    "- web検索で材料が確認できない銘柄について憶測は書かない。"
+    "地合いの影響として他銘柄とまとめて短く触れるにとどめる。"
 )
+
+_MD_LINK_IN_PARENS = re.compile(r"\(\s*\[[^\]]*\]\([^)]*\)\s*\)")
+_MD_LINK = re.compile(r"\[[^\]]*\]\([^)]*\)")
+_BARE_URL = re.compile(r"https?://\S+")
+_MULTI_SPACE = re.compile(r"[ \t]{2,}")
+_MULTI_NEWLINE = re.compile(r"\n{3,}")
+
+
+def _strip_citations(text: str) -> str:
+    """web_search由来のURL引用・Markdownリンク・裸URLを取り除く。"""
+    text = _MD_LINK_IN_PARENS.sub("", text)
+    text = _MD_LINK.sub("", text)
+    text = _BARE_URL.sub("", text)
+    text = _MULTI_SPACE.sub(" ", text)
+    text = _MULTI_NEWLINE.sub("\n\n", text)
+    return text.strip()
 
 
 def _format_performers_for_prompt(
@@ -51,7 +80,7 @@ def _format_performers_for_prompt(
         f"【上昇トップ】\n{top_block}\n\n"
         f"【下落ワースト】\n{bottom_block}\n\n"
         "これらの銘柄について、直近1週間の値動きの主因をweb検索で調査し、"
-        "システム指示に従って1000文字以内でまとめてください。"
+        "システム指示に従い段落形式の散文で1000文字以内にまとめてください。"
     )
 
 
@@ -111,7 +140,8 @@ async def generate_change_reasons(
         if not text:
             logger.warning("OpenAIレスポンスの本文が空でした action=external_io")
             return None
-        trimmed = _trim_to_max_chars(text)
+        cleaned = _strip_citations(text)
+        trimmed = _trim_to_max_chars(cleaned)
         logger.info("変動理由生成完了 action=external_io length={}", len(trimmed))
         return trimmed
     except Exception:

--- a/src/api/stock/services/change_reason_service.py
+++ b/src/api/stock/services/change_reason_service.py
@@ -1,0 +1,122 @@
+"""週次騰落率ランキングの「変動理由」を OpenAI gpt-5.4 + web 検索で生成する。
+
+LINE 週次騰落率通知の Flex Message に続けて送るテキスト本文を生成するサービス。
+"""
+
+from loguru import logger
+
+from ..database import settings
+from ..schemas import StockWeeklyPerformance
+from .classification_service import get_openai_client
+
+OPENAI_MODEL: str = "gpt-5.4"
+REASONING_EFFORT: str = "high"
+MAX_OUTPUT_CHARS: int = 1000
+REQUEST_TIMEOUT_SEC: float = 180.0
+
+CHANGE_REASON_SYSTEM_PROMPT: str = (
+    "あなたは日本の個人投資家向けの株式市況アナリストです。"
+    "入力された「週間騰落率ランキング」（上位5銘柄・下位5銘柄、最大10銘柄、日本株と米国株が混在）について、"
+    "直近1週間の値動きの主因をweb検索で調査し、日本語でまとめてください。\n\n"
+    "必須の遵守事項:\n"
+    "- 全体で1000文字以内（厳守）。超えそうなら銘柄を統合して要約すること。\n"
+    "- 同じセクターで連れ高・連れ安した銘柄、個別材料が乏しい銘柄はまとめて1行で記述してよい。"
+    "例: 「AAAA・BBBBは半導体セクターの連れ高」\n"
+    "- 個別に明確な材料（決算・ガイダンス・M&A・アナリスト格上げ/格下げ・規制・ショック等）がある銘柄は"
+    "銘柄ごとに1〜2文で説明。\n"
+    "- 銘柄の識別は「銘柄名」のみ。銘柄コード（ティッカー/証券コード）は冗長なので出力に含めない。\n"
+    "- 絵文字・記号による装飾は使わない。文字数節約のためプレーンな日本語テキストのみ。\n"
+    "- 出典URLや引用マーク、脚注は出力に含めない。\n"
+    "- web検索で確実な情報が見つからない銘柄は推測せず"
+    "「特段の材料は確認できず（地合いの影響と思われる）」と簡潔に記載する。\n"
+    "- 冗長な前置き・まとめの挨拶・免責事項は入れない。本文のみ。\n"
+    "- 構成: 最初に「上昇トップ」セクション、次に「下落ワースト」セクション。"
+    "各セクションは銘柄（またはまとめたグループ）ごとに改行。"
+)
+
+
+def _format_performers_for_prompt(
+    top_performers: list[StockWeeklyPerformance],
+    bottom_performers: list[StockWeeklyPerformance],
+) -> str:
+    """OpenAI への入力として、上位・下位銘柄のリストを文字列化する。"""
+
+    def _format_line(rank: int, p: StockWeeklyPerformance) -> str:
+        sign = "+" if p.change_rate >= 0 else ""
+        return f"{rank}. {p.name}（{p.symbol}）: {sign}{p.change_rate:.2f}%"
+
+    top_block = "\n".join(_format_line(i + 1, p) for i, p in enumerate(top_performers))
+    bottom_block = "\n".join(_format_line(i + 1, p) for i, p in enumerate(bottom_performers))
+
+    return (
+        "対象期間: 直近1週間（およそ過去5営業日）\n\n"
+        f"【上昇トップ】\n{top_block}\n\n"
+        f"【下落ワースト】\n{bottom_block}\n\n"
+        "これらの銘柄について、直近1週間の値動きの主因をweb検索で調査し、"
+        "システム指示に従って1000文字以内でまとめてください。"
+    )
+
+
+def _trim_to_max_chars(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
+    """指定文字数を超えたら句点または改行で切り詰め、末尾に「…」を付加する。"""
+    if len(text) <= max_chars:
+        return text
+
+    truncated = text[: max_chars - 1]
+    for sep in ("。", "\n"):
+        idx = truncated.rfind(sep)
+        if idx > max_chars // 2:
+            return truncated[: idx + 1] + "…"
+
+    return truncated + "…"
+
+
+async def generate_change_reasons(
+    top_performers: list[StockWeeklyPerformance],
+    bottom_performers: list[StockWeeklyPerformance],
+) -> str | None:
+    """騰落銘柄リストから変動理由テキストを生成する。
+
+    Args:
+        top_performers: 上昇トップ銘柄のリスト
+        bottom_performers: 下落ワースト銘柄のリスト
+
+    Returns:
+        1000文字以内の日本語テキスト。API未設定・失敗・空レスポンス時は None。
+    """
+    if not settings.OPENAI_API_KEY:
+        logger.warning("OPENAI_API_KEYが未設定のため変動理由生成をスキップします action=external_io")
+        return None
+
+    if not top_performers and not bottom_performers:
+        logger.info("対象銘柄が空のため変動理由生成をスキップします action=external_io")
+        return None
+
+    user_input = _format_performers_for_prompt(top_performers, bottom_performers)
+
+    try:
+        client = get_openai_client()
+        logger.info(
+            "OpenAIに変動理由生成リクエストを送信します action=external_io model={} top={} bottom={}",
+            OPENAI_MODEL,
+            len(top_performers),
+            len(bottom_performers),
+        )
+        response = await client.responses.create(
+            model=OPENAI_MODEL,
+            instructions=CHANGE_REASON_SYSTEM_PROMPT,
+            input=user_input,
+            reasoning={"effort": REASONING_EFFORT},
+            tools=[{"type": "web_search"}],
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+        text = response.output_text
+        if not text:
+            logger.warning("OpenAIレスポンスの本文が空でした action=external_io")
+            return None
+        trimmed = _trim_to_max_chars(text)
+        logger.info("変動理由生成完了 action=external_io length={}", len(trimmed))
+        return trimmed
+    except Exception:
+        logger.exception("変動理由生成失敗 action=external_io")
+        return None

--- a/src/api/stock/services/classification_service.py
+++ b/src/api/stock/services/classification_service.py
@@ -17,7 +17,7 @@ _openai_client: AsyncOpenAI | None = None
 def get_openai_client() -> AsyncOpenAI:
     global _openai_client
     if _openai_client is None:
-        _openai_client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+        _openai_client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY, max_retries=1)
     return _openai_client
 
 

--- a/src/api/stock/services/notification_service.py
+++ b/src/api/stock/services/notification_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..utils.datetime import now_jst
-from .change_reason_service import generate_change_reasons
+from .change_reason_service import ChangeReasonSections, generate_change_reasons
 
 # 環境変数のロード
 load_dotenv()
@@ -405,43 +405,76 @@ def _build_ranking_row(rank: int, name: str, symbol: str, change_rate: float) ->
     }
 
 
-def _build_weekly_performance_flex_message(top_performers: list, bottom_performers: list) -> dict:
+def _section_heading(text: str) -> dict:
+    return {
+        "type": "text",
+        "text": text,
+        "weight": "bold",
+        "size": "md",
+        "margin": "lg",
+        "color": "#333333",
+    }
+
+
+def _section_body(text: str, margin: str = "md") -> dict:
+    return {
+        "type": "text",
+        "text": text,
+        "wrap": True,
+        "size": "sm",
+        "margin": margin,
+        "color": "#555555",
+    }
+
+
+def _ranking_contents(performers: list) -> list[dict]:
+    if not performers:
+        return [{"type": "text", "text": "データなし", "size": "sm", "color": "#666666", "margin": "md"}]
+    return [_build_ranking_row(i, p.name, p.symbol, p.change_rate) for i, p in enumerate(performers, 1)]
+
+
+def _build_weekly_performance_flex_message(
+    top_performers: list,
+    bottom_performers: list,
+    sections: ChangeReasonSections | None = None,
+) -> dict:
     """
     週間騰落率ランキングのFlex Messageを作成する
 
     Args:
         top_performers (list): 上昇トップのリスト
         bottom_performers (list): 下落ワーストのリスト
+        sections: 変動理由セクション（概況/上昇解説/下落解説）。None ならランキングのみ表示。
 
     Returns:
         dict: LINE Flex Message形式の辞書
     """
-    # 日本時間の現在時刻
-    current_time = now_jst()
-    today = current_time.strftime("%Y/%m/%d")
+    today = now_jst().strftime("%Y/%m/%d")
+    top_contents = _ranking_contents(top_performers)
+    bottom_contents = _ranking_contents(bottom_performers)
 
-    # 上昇トップ5のコンテンツ
-    top_contents = []
-    if top_performers:
-        for i, perf in enumerate(top_performers, 1):
-            top_contents.append(_build_ranking_row(i, perf.name, perf.symbol, perf.change_rate))
-    else:
-        top_contents.append(
-            {"type": "text", "text": "データなし", "size": "sm", "color": "#666666", "margin": "md"}
-        )
+    body_contents: list[dict] = [{"type": "separator", "color": "#E0E0E0"}]
 
-    # 下落ワースト5のコンテンツ
-    bottom_contents = []
-    if bottom_performers:
-        for i, perf in enumerate(bottom_performers, 1):
-            bottom_contents.append(_build_ranking_row(i, perf.name, perf.symbol, perf.change_rate))
-    else:
-        bottom_contents.append(
-            {"type": "text", "text": "データなし", "size": "sm", "color": "#666666", "margin": "md"}
-        )
+    if sections:
+        body_contents.append(_section_heading("マーケット概況"))
+        body_contents.append(_section_body(sections.market_overview))
+        body_contents.append({"type": "separator", "margin": "xl", "color": "#E0E0E0"})
+
+    body_contents.append(_section_heading("上昇トップ5"))
+    body_contents.append({"type": "box", "layout": "vertical", "contents": top_contents, "margin": "sm"})
+    if sections:
+        body_contents.append(_section_body(sections.top_commentary, margin="lg"))
+
+    body_contents.append({"type": "separator", "margin": "xl", "color": "#E0E0E0"})
+
+    body_contents.append(_section_heading("下落ワースト5"))
+    body_contents.append({"type": "box", "layout": "vertical", "contents": bottom_contents, "margin": "sm"})
+    if sections:
+        body_contents.append(_section_body(sections.bottom_commentary, margin="lg"))
 
     return {
         "type": "bubble",
+        "size": "giga",
         "header": {
             "type": "box",
             "layout": "vertical",
@@ -463,28 +496,7 @@ def _build_weekly_performance_flex_message(top_performers: list, bottom_performe
         "body": {
             "type": "box",
             "layout": "vertical",
-            "contents": [
-                {"type": "separator", "color": "#E0E0E0"},
-                {
-                    "type": "text",
-                    "text": "上昇トップ5",
-                    "weight": "bold",
-                    "size": "md",
-                    "margin": "lg",
-                    "color": "#333333",
-                },
-                {"type": "box", "layout": "vertical", "contents": top_contents, "margin": "sm"},
-                {"type": "separator", "margin": "xl", "color": "#E0E0E0"},
-                {
-                    "type": "text",
-                    "text": "下落ワースト5",
-                    "weight": "bold",
-                    "size": "md",
-                    "margin": "lg",
-                    "color": "#333333",
-                },
-                {"type": "box", "layout": "vertical", "contents": bottom_contents, "margin": "sm"},
-            ],
+            "contents": body_contents,
             "paddingAll": "20px",
             "backgroundColor": "#FFFFFF",
         },
@@ -524,8 +536,8 @@ async def send_weekly_performance_notification(
             logger.error(f"ユーザーID {user_id} のLINE UserIDが設定されていません")
             return False
 
-        # Flex Messageの作成
-        flex_contents = _build_weekly_performance_flex_message(top_performers, bottom_performers)
+        sections = await generate_change_reasons(top_performers, bottom_performers)
+        flex_contents = _build_weekly_performance_flex_message(top_performers, bottom_performers, sections)
 
         flex_message = {
             "type": "flex",
@@ -533,11 +545,7 @@ async def send_weekly_performance_notification(
             "contents": flex_contents,
         }
 
-        reason_text = await generate_change_reasons(top_performers, bottom_performers)
-
         messages: list[dict] = [flex_message]
-        if reason_text:
-            messages.append({"type": "text", "text": reason_text})
 
         headers = {"Authorization": f"Bearer {line_token}", "Content-Type": "application/json"}
 

--- a/src/api/stock/services/notification_service.py
+++ b/src/api/stock/services/notification_service.py
@@ -533,7 +533,6 @@ async def send_weekly_performance_notification(
             "contents": flex_contents,
         }
 
-        # OpenAI で変動理由テキストを生成（失敗時は Flex のみ送信）
         reason_text = await generate_change_reasons(top_performers, bottom_performers)
 
         messages: list[dict] = [flex_message]

--- a/src/api/stock/services/notification_service.py
+++ b/src/api/stock/services/notification_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..utils.datetime import now_jst
+from .change_reason_service import generate_change_reasons
 
 # 環境変数のロード
 load_dotenv()
@@ -532,9 +533,16 @@ async def send_weekly_performance_notification(
             "contents": flex_contents,
         }
 
+        # OpenAI で変動理由テキストを生成（失敗時は Flex のみ送信）
+        reason_text = await generate_change_reasons(top_performers, bottom_performers)
+
+        messages: list[dict] = [flex_message]
+        if reason_text:
+            messages.append({"type": "text", "text": reason_text})
+
         headers = {"Authorization": f"Bearer {line_token}", "Content-Type": "application/json"}
 
-        data = {"to": line_user_id, "messages": [flex_message]}
+        data = {"to": line_user_id, "messages": messages}
 
         # LINE Message APIにリクエストを送信
         async with httpx.AsyncClient() as client:

--- a/src/api/tests/api/test_weekly_performance.py
+++ b/src/api/tests/api/test_weekly_performance.py
@@ -1,12 +1,16 @@
 """週間騰落率通知APIのテスト"""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from stock.schemas import StockWeeklyPerformance
-from stock.services.notification_service import _build_ranking_row
-from stock.services.notification_service import WEEKLY_PERFORMANCE_COLOR_GREEN, WEEKLY_PERFORMANCE_COLOR_RED
+from stock.services.notification_service import (
+    WEEKLY_PERFORMANCE_COLOR_GREEN,
+    WEEKLY_PERFORMANCE_COLOR_RED,
+    _build_ranking_row,
+    send_weekly_performance_notification,
+)
 from stock.services.weekly_performance_service import get_top_bottom_performers
 
 
@@ -251,3 +255,90 @@ async def test_weekly_performance_notify_endpoint(
 
     # 通知が送信されたこと
     assert data["notification_sent"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_weekly_performance_notification_includes_reason_text(monkeypatch, mocker):
+    """generate_change_reasons が文字列を返すとき、LINE push に Flex + Text の2件が送られること"""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "dummy-token")
+
+    mocker.patch(
+        "stock.services.notification_service.NotificationService.get_line_user_id",
+        new_callable=AsyncMock,
+        return_value="U1234567890",
+    )
+    mocker.patch(
+        "stock.services.notification_service.generate_change_reasons",
+        new_callable=AsyncMock,
+        return_value="トヨタ自動車は好決算で上昇。任天堂はガイダンス下方修正で下落。",
+    )
+
+    mock_line_response = MagicMock()
+    mock_line_response.status_code = 200
+    mock_post = mocker.patch(
+        "httpx.AsyncClient.post",
+        new_callable=AsyncMock,
+        return_value=mock_line_response,
+    )
+
+    top = [
+        StockWeeklyPerformance(
+            symbol="7203", name="トヨタ自動車", latest_price=3300.0, old_price=3000.0, change_rate=10.0
+        )
+    ]
+    bottom = [
+        StockWeeklyPerformance(
+            symbol="7974", name="任天堂", latest_price=6500.0, old_price=7000.0, change_rate=-7.14
+        )
+    ]
+
+    result = await send_weekly_performance_notification(
+        user_id=1, top_performers=top, bottom_performers=bottom, db=None
+    )
+
+    assert result is True
+    posted = mock_post.call_args.kwargs["json"]
+    assert len(posted["messages"]) == 2
+    assert posted["messages"][0]["type"] == "flex"
+    assert posted["messages"][1]["type"] == "text"
+    assert "トヨタ自動車は好決算" in posted["messages"][1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_weekly_performance_notification_falls_back_without_reason(monkeypatch, mocker):
+    """generate_change_reasons が None を返すとき、LINE push は Flex のみ"""
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "dummy-token")
+
+    mocker.patch(
+        "stock.services.notification_service.NotificationService.get_line_user_id",
+        new_callable=AsyncMock,
+        return_value="U1234567890",
+    )
+    mocker.patch(
+        "stock.services.notification_service.generate_change_reasons",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+    mock_line_response = MagicMock()
+    mock_line_response.status_code = 200
+    mock_post = mocker.patch(
+        "httpx.AsyncClient.post",
+        new_callable=AsyncMock,
+        return_value=mock_line_response,
+    )
+
+    top = [
+        StockWeeklyPerformance(
+            symbol="7203", name="トヨタ自動車", latest_price=3300.0, old_price=3000.0, change_rate=10.0
+        )
+    ]
+
+    result = await send_weekly_performance_notification(
+        user_id=1, top_performers=top, bottom_performers=[], db=None
+    )
+
+    assert result is True
+    posted = mock_post.call_args.kwargs["json"]
+    assert len(posted["messages"]) == 1
+    assert posted["messages"][0]["type"] == "flex"

--- a/src/api/tests/api/test_weekly_performance.py
+++ b/src/api/tests/api/test_weekly_performance.py
@@ -1,10 +1,12 @@
 """週間騰落率通知APIのテスト"""
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from stock.schemas import StockWeeklyPerformance
+from stock.services.change_reason_service import ChangeReasonSections
 from stock.services.notification_service import (
     WEEKLY_PERFORMANCE_COLOR_GREEN,
     WEEKLY_PERFORMANCE_COLOR_RED,
@@ -258,8 +260,8 @@ async def test_weekly_performance_notify_endpoint(
 
 
 @pytest.mark.asyncio
-async def test_send_weekly_performance_notification_includes_reason_text(monkeypatch, mocker):
-    """generate_change_reasons が文字列を返すとき、LINE push に Flex + Text の2件が送られること"""
+async def test_send_weekly_performance_notification_embeds_sections_in_flex(monkeypatch, mocker):
+    """generate_change_reasons が ChangeReasonSections を返すとき、Flex 本文に各セクション文が含まれる"""
     monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "dummy-token")
 
     mocker.patch(
@@ -270,7 +272,11 @@ async def test_send_weekly_performance_notification_includes_reason_text(monkeyp
     mocker.patch(
         "stock.services.notification_service.generate_change_reasons",
         new_callable=AsyncMock,
-        return_value="トヨタ自動車は好決算で上昇。任天堂はガイダンス下方修正で下落。",
+        return_value=ChangeReasonSections(
+            market_overview="今週は地合い改善。",
+            top_commentary="トヨタ自動車は好決算で上昇。",
+            bottom_commentary="任天堂はガイダンス下方修正で下落。",
+        ),
     )
 
     mock_line_response = MagicMock()
@@ -298,10 +304,14 @@ async def test_send_weekly_performance_notification_includes_reason_text(monkeyp
 
     assert result is True
     posted = mock_post.call_args.kwargs["json"]
-    assert len(posted["messages"]) == 2
+    assert len(posted["messages"]) == 1
     assert posted["messages"][0]["type"] == "flex"
-    assert posted["messages"][1]["type"] == "text"
-    assert "トヨタ自動車は好決算" in posted["messages"][1]["text"]
+
+    body_json = json.dumps(posted["messages"][0]["contents"], ensure_ascii=False)
+    assert "マーケット概況" in body_json
+    assert "今週は地合い改善。" in body_json
+    assert "トヨタ自動車は好決算で上昇。" in body_json
+    assert "任天堂はガイダンス下方修正で下落。" in body_json
 
 
 @pytest.mark.asyncio

--- a/src/api/tests/services/test_change_reason_service.py
+++ b/src/api/tests/services/test_change_reason_service.py
@@ -1,0 +1,192 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from stock.schemas import StockWeeklyPerformance
+from stock.services.change_reason_service import (
+    _format_performers_for_prompt,
+    _trim_to_max_chars,
+    generate_change_reasons,
+)
+
+
+def _make_perf(symbol: str, name: str, change_rate: float) -> StockWeeklyPerformance:
+    return StockWeeklyPerformance(
+        symbol=symbol,
+        name=name,
+        latest_price=100.0,
+        old_price=100.0,
+        change_rate=change_rate,
+    )
+
+
+class TestTrimToMaxChars:
+    def test_under_limit_returns_as_is(self):
+        text = "あ" * 800
+        assert _trim_to_max_chars(text, max_chars=1000) == text
+
+    def test_over_limit_trims_with_ellipsis(self):
+        text = "あ" * 1200
+        result = _trim_to_max_chars(text, max_chars=1000)
+        assert len(result) <= 1000
+        assert result.endswith("…")
+
+    def test_trims_at_period_boundary(self):
+        body = "第一文です。" + "あ" * 600 + "。" + "い" * 400
+        result = _trim_to_max_chars(body, max_chars=1000)
+        assert len(result) <= 1000
+        assert result.endswith("。…")
+
+
+class TestFormatPerformersForPrompt:
+    def test_includes_name_symbol_and_change_rate(self):
+        top = [_make_perf("7203", "トヨタ自動車", 8.42)]
+        bottom = [_make_perf("NVDA", "NVIDIA", -5.12)]
+
+        result = _format_performers_for_prompt(top, bottom)
+
+        assert "トヨタ自動車" in result
+        assert "7203" in result
+        assert "+8.42%" in result
+        assert "NVIDIA" in result
+        assert "NVDA" in result
+        assert "-5.12%" in result
+        assert "【上昇トップ】" in result
+        assert "【下落ワースト】" in result
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_success():
+    """OpenAI が output_text を返すとき、戻り値が同じ文字列になること"""
+    mock_response = MagicMock()
+    mock_response.output_text = (
+        "上昇トップ: トヨタ自動車は好決算。\n下落ワースト: 任天堂はガイダンス下方修正。"
+    )
+
+    mock_client = AsyncMock()
+    mock_client.responses.create.return_value = mock_response
+
+    top = [_make_perf("7203", "トヨタ自動車", 8.42)]
+    bottom = [_make_perf("7974", "任天堂", -6.50)]
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons(top, bottom)
+
+    assert result == mock_response.output_text
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_no_api_key():
+    """APIキー未設定時は None を返し、APIを呼ばないこと"""
+    mock_client = AsyncMock()
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = ""
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons(
+                [_make_perf("7203", "トヨタ自動車", 8.42)],
+                [_make_perf("7974", "任天堂", -6.50)],
+            )
+
+    assert result is None
+    mock_client.responses.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_empty_performers():
+    """対象銘柄が空の場合は None を返し、APIを呼ばないこと"""
+    mock_client = AsyncMock()
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons([], [])
+
+    assert result is None
+    mock_client.responses.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_api_error():
+    """API 例外時は None を返すこと"""
+    mock_client = AsyncMock()
+    mock_client.responses.create.side_effect = Exception("API Error")
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons(
+                [_make_perf("7203", "トヨタ自動車", 8.42)],
+                [_make_perf("7974", "任天堂", -6.50)],
+            )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_empty_output_text():
+    """output_text が空文字のときは None を返すこと"""
+    mock_response = MagicMock()
+    mock_response.output_text = ""
+
+    mock_client = AsyncMock()
+    mock_client.responses.create.return_value = mock_response
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons(
+                [_make_perf("7203", "トヨタ自動車", 8.42)],
+                [],
+            )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_trims_long_output():
+    """1000文字超の出力はトリミングされること"""
+    mock_response = MagicMock()
+    mock_response.output_text = "あ" * 1500
+
+    mock_client = AsyncMock()
+    mock_client.responses.create.return_value = mock_response
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            result = await generate_change_reasons(
+                [_make_perf("7203", "トヨタ自動車", 8.42)],
+                [],
+            )
+
+    assert result is not None
+    assert len(result) <= 1000
+    assert result.endswith("…")
+
+
+@pytest.mark.asyncio
+async def test_generate_change_reasons_uses_expected_openai_params():
+    """responses.create が想定パラメータで呼ばれること"""
+    mock_response = MagicMock()
+    mock_response.output_text = "テスト"
+
+    mock_client = AsyncMock()
+    mock_client.responses.create.return_value = mock_response
+
+    with patch("stock.services.change_reason_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"
+        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
+            await generate_change_reasons(
+                [_make_perf("7203", "トヨタ自動車", 8.42)],
+                [_make_perf("7974", "任天堂", -6.50)],
+            )
+
+    call_kwargs = mock_client.responses.create.call_args.kwargs
+    assert call_kwargs["model"] == "gpt-5.4"
+    assert call_kwargs["reasoning"] == {"effort": "high"}
+    assert call_kwargs["tools"] == [{"type": "web_search"}]
+    assert "トヨタ自動車" in call_kwargs["input"]
+    assert "任天堂" in call_kwargs["input"]

--- a/src/api/tests/services/test_change_reason_service.py
+++ b/src/api/tests/services/test_change_reason_service.py
@@ -4,7 +4,10 @@ import pytest
 
 from stock.schemas import StockWeeklyPerformance
 from stock.services.change_reason_service import (
+    ChangeReasonSections,
     _format_performers_for_prompt,
+    _parse_sections,
+    _strip_citations,
     _trim_to_max_chars,
     generate_change_reasons,
 )
@@ -18,6 +21,10 @@ def _make_perf(symbol: str, name: str, change_rate: float) -> StockWeeklyPerform
         old_price=100.0,
         change_rate=change_rate,
     )
+
+
+def _make_marker_text(market: str, top: str, bottom: str) -> str:
+    return f"===市場概況===\n{market}\n\n===上昇解説===\n{top}\n\n===下落解説===\n{bottom}\n"
 
 
 @pytest.fixture
@@ -36,14 +43,41 @@ def mock_openai_client():
 
 class TestTrimToMaxChars:
     def test_under_limit_returns_as_is(self):
-        text = "あ" * 800
-        assert _trim_to_max_chars(text, max_chars=1000) == text
+        text = "あ" * 300
+        assert _trim_to_max_chars(text, max_chars=400) == text
 
     def test_over_limit_trims_with_ellipsis(self):
-        text = "あ" * 1200
-        result = _trim_to_max_chars(text, max_chars=1000)
-        assert len(result) <= 1000
+        text = "あ" * 600
+        result = _trim_to_max_chars(text, max_chars=400)
+        assert len(result) <= 400
         assert result.endswith("…")
+
+
+class TestStripCitations:
+    def test_removes_markdown_link_in_parens(self):
+        text = "本文 ([diamond.jp](https://diamond.jp/a?x=1)) 続き"
+        assert _strip_citations(text) == "本文 続き"
+
+    def test_removes_bare_url(self):
+        assert _strip_citations("aaa https://example.com/x bbb") == "aaa bbb"
+
+
+class TestParseSections:
+    def test_parses_three_sections(self):
+        text = _make_marker_text("地合いの解説", "上昇の解説", "下落の解説")
+        sections = _parse_sections(text)
+        assert sections == ChangeReasonSections(
+            market_overview="地合いの解説",
+            top_commentary="上昇の解説",
+            bottom_commentary="下落の解説",
+        )
+
+    def test_returns_none_when_marker_missing(self):
+        assert _parse_sections("===市場概況===\n本文\n===上昇解説===\n上昇") is None
+
+    def test_returns_none_when_section_empty(self):
+        text = _make_marker_text("", "上昇", "下落")
+        assert _parse_sections(text) is None
 
 
 class TestFormatPerformersForPrompt:
@@ -66,8 +100,10 @@ class TestFormatPerformersForPrompt:
 @pytest.mark.asyncio
 async def test_generate_change_reasons_success(mock_settings, mock_openai_client):
     mock_response = MagicMock()
-    mock_response.output_text = (
-        "上昇トップ: トヨタ自動車は好決算。\n下落ワースト: 任天堂はガイダンス下方修正。"
+    mock_response.output_text = _make_marker_text(
+        "今週は地合い改善。",
+        "トヨタは好決算で買われた。",
+        "任天堂はガイダンス下方修正で売られた。",
     )
     mock_openai_client.responses.create.return_value = mock_response
 
@@ -76,7 +112,11 @@ async def test_generate_change_reasons_success(mock_settings, mock_openai_client
 
     result = await generate_change_reasons(top, bottom)
 
-    assert result == mock_response.output_text
+    assert result == ChangeReasonSections(
+        market_overview="今週は地合い改善。",
+        top_commentary="トヨタは好決算で買われた。",
+        bottom_commentary="任天堂はガイダンス下方修正で売られた。",
+    )
 
 
 @pytest.mark.asyncio
@@ -102,19 +142,3 @@ async def test_generate_change_reasons_api_error(mock_settings, mock_openai_clie
     )
 
     assert result is None
-
-
-@pytest.mark.asyncio
-async def test_generate_change_reasons_trims_long_output(mock_settings, mock_openai_client):
-    mock_response = MagicMock()
-    mock_response.output_text = "あ" * 1500
-    mock_openai_client.responses.create.return_value = mock_response
-
-    result = await generate_change_reasons(
-        [_make_perf("7203", "トヨタ自動車", 8.42)],
-        [],
-    )
-
-    assert result is not None
-    assert len(result) <= 1000
-    assert result.endswith("…")

--- a/src/api/tests/services/test_change_reason_service.py
+++ b/src/api/tests/services/test_change_reason_service.py
@@ -20,6 +20,20 @@ def _make_perf(symbol: str, name: str, change_rate: float) -> StockWeeklyPerform
     )
 
 
+@pytest.fixture
+def mock_settings():
+    with patch("stock.services.change_reason_service.settings") as m:
+        m.OPENAI_API_KEY = "test-key"
+        yield m
+
+
+@pytest.fixture
+def mock_openai_client():
+    client = AsyncMock()
+    with patch("stock.services.change_reason_service.get_openai_client", return_value=client):
+        yield client
+
+
 class TestTrimToMaxChars:
     def test_under_limit_returns_as_is(self):
         text = "あ" * 800
@@ -30,12 +44,6 @@ class TestTrimToMaxChars:
         result = _trim_to_max_chars(text, max_chars=1000)
         assert len(result) <= 1000
         assert result.endswith("…")
-
-    def test_trims_at_period_boundary(self):
-        body = "第一文です。" + "あ" * 600 + "。" + "い" * 400
-        result = _trim_to_max_chars(body, max_chars=1000)
-        assert len(result) <= 1000
-        assert result.endswith("。…")
 
 
 class TestFormatPerformersForPrompt:
@@ -56,137 +64,57 @@ class TestFormatPerformersForPrompt:
 
 
 @pytest.mark.asyncio
-async def test_generate_change_reasons_success():
-    """OpenAI が output_text を返すとき、戻り値が同じ文字列になること"""
+async def test_generate_change_reasons_success(mock_settings, mock_openai_client):
     mock_response = MagicMock()
     mock_response.output_text = (
         "上昇トップ: トヨタ自動車は好決算。\n下落ワースト: 任天堂はガイダンス下方修正。"
     )
-
-    mock_client = AsyncMock()
-    mock_client.responses.create.return_value = mock_response
+    mock_openai_client.responses.create.return_value = mock_response
 
     top = [_make_perf("7203", "トヨタ自動車", 8.42)]
     bottom = [_make_perf("7974", "任天堂", -6.50)]
 
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons(top, bottom)
+    result = await generate_change_reasons(top, bottom)
 
     assert result == mock_response.output_text
 
 
 @pytest.mark.asyncio
-async def test_generate_change_reasons_no_api_key():
-    """APIキー未設定時は None を返し、APIを呼ばないこと"""
-    mock_client = AsyncMock()
+async def test_generate_change_reasons_no_api_key(mock_settings, mock_openai_client):
+    mock_settings.OPENAI_API_KEY = ""
 
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = ""
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons(
-                [_make_perf("7203", "トヨタ自動車", 8.42)],
-                [_make_perf("7974", "任天堂", -6.50)],
-            )
+    result = await generate_change_reasons(
+        [_make_perf("7203", "トヨタ自動車", 8.42)],
+        [_make_perf("7974", "任天堂", -6.50)],
+    )
 
     assert result is None
-    mock_client.responses.create.assert_not_called()
+    mock_openai_client.responses.create.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_generate_change_reasons_empty_performers():
-    """対象銘柄が空の場合は None を返し、APIを呼ばないこと"""
-    mock_client = AsyncMock()
+async def test_generate_change_reasons_api_error(mock_settings, mock_openai_client):
+    mock_openai_client.responses.create.side_effect = Exception("API Error")
 
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons([], [])
-
-    assert result is None
-    mock_client.responses.create.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_generate_change_reasons_api_error():
-    """API 例外時は None を返すこと"""
-    mock_client = AsyncMock()
-    mock_client.responses.create.side_effect = Exception("API Error")
-
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons(
-                [_make_perf("7203", "トヨタ自動車", 8.42)],
-                [_make_perf("7974", "任天堂", -6.50)],
-            )
+    result = await generate_change_reasons(
+        [_make_perf("7203", "トヨタ自動車", 8.42)],
+        [_make_perf("7974", "任天堂", -6.50)],
+    )
 
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_generate_change_reasons_empty_output_text():
-    """output_text が空文字のときは None を返すこと"""
-    mock_response = MagicMock()
-    mock_response.output_text = ""
-
-    mock_client = AsyncMock()
-    mock_client.responses.create.return_value = mock_response
-
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons(
-                [_make_perf("7203", "トヨタ自動車", 8.42)],
-                [],
-            )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_generate_change_reasons_trims_long_output():
-    """1000文字超の出力はトリミングされること"""
+async def test_generate_change_reasons_trims_long_output(mock_settings, mock_openai_client):
     mock_response = MagicMock()
     mock_response.output_text = "あ" * 1500
+    mock_openai_client.responses.create.return_value = mock_response
 
-    mock_client = AsyncMock()
-    mock_client.responses.create.return_value = mock_response
-
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            result = await generate_change_reasons(
-                [_make_perf("7203", "トヨタ自動車", 8.42)],
-                [],
-            )
+    result = await generate_change_reasons(
+        [_make_perf("7203", "トヨタ自動車", 8.42)],
+        [],
+    )
 
     assert result is not None
     assert len(result) <= 1000
     assert result.endswith("…")
-
-
-@pytest.mark.asyncio
-async def test_generate_change_reasons_uses_expected_openai_params():
-    """responses.create が想定パラメータで呼ばれること"""
-    mock_response = MagicMock()
-    mock_response.output_text = "テスト"
-
-    mock_client = AsyncMock()
-    mock_client.responses.create.return_value = mock_response
-
-    with patch("stock.services.change_reason_service.settings") as mock_settings:
-        mock_settings.OPENAI_API_KEY = "test-key"
-        with patch("stock.services.change_reason_service.get_openai_client", return_value=mock_client):
-            await generate_change_reasons(
-                [_make_perf("7203", "トヨタ自動車", 8.42)],
-                [_make_perf("7974", "任天堂", -6.50)],
-            )
-
-    call_kwargs = mock_client.responses.create.call_args.kwargs
-    assert call_kwargs["model"] == "gpt-5.4"
-    assert call_kwargs["reasoning"] == {"effort": "high"}
-    assert call_kwargs["tools"] == [{"type": "web_search"}]
-    assert "トヨタ自動車" in call_kwargs["input"]
-    assert "任天堂" in call_kwargs["input"]


### PR DESCRIPTION
OpenAI gpt-5.4 (reasoning=high) + web検索で上位5・下位5銘柄の直近1週間の値動き
の主因を1000文字以内にまとめ、既存Flex Messageと同じLINE pushにtextメッセージ
として同梱して送る。連れ高・連れ安で個別材料が薄い銘柄はまとめて要約可とし、
OpenAI失敗時はFlexのみ送信するフォールバックを持つ。

https://claude.ai/code/session_01AtbSjnqqhADM4ZoTbhzc6E