### PR TITLE
feat(web): Holdings画面にCSVエクスポート機能を追加

### DIFF
--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -68,7 +68,7 @@ describe("holdingsToCsv", () => {
     const lines = csv.replace(BOM, "").split("\r\n")
     expect(lines).toHaveLength(2)
     expect(lines[1]).toBe(
-      "7203,トヨタ自動車,100,250000,50000,25.00,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
+      "7203,トヨタ自動車,100,250000,50000,25,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
     )
   })
 
@@ -83,6 +83,27 @@ describe("holdingsToCsv", () => {
     const fields = lines[1].split(",")
     expect(fields[5]).toBe("90.52")
     expect(fields[9]).toBe("-47.79")
+  })
+
+  it("株数は浮動小数点誤差を除き小数4桁までに丸める", () => {
+    const holding: Holding = { ...baseHolding, quantity: 50.80600000000001 }
+    const csv = holdingsToCsv([holding])
+    const fields = csv.replace(BOM, "").split("\r\n")[1].split(",")
+    expect(fields[2]).toBe("50.806")
+  })
+
+  it("金額は浮動小数点誤差を除き小数2桁までに丸め、末尾ゼロを削除する", () => {
+    const holding: Holding = {
+      ...baseHolding,
+      market_value: 1929510.2680000004,
+      unrealized_pl: 727.296600000016,
+      total_pl: 16975.6829,
+    }
+    const csv = holdingsToCsv([holding])
+    const fields = csv.replace(BOM, "").split("\r\n")[1].split(",")
+    expect(fields[3]).toBe("1929510.27")
+    expect(fields[4]).toBe("727.3")
+    expect(fields[8]).toBe("16975.68")
   })
 
   it("最終更新日時のマイクロ秒を削除する", () => {

--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -68,8 +68,28 @@ describe("holdingsToCsv", () => {
     const lines = csv.replace(BOM, "").split("\r\n")
     expect(lines).toHaveLength(2)
     expect(lines[1]).toBe(
-      "7203,トヨタ自動車,100,250000,50000,25,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
+      "7203,トヨタ自動車,100,250000,50000,25.00,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
     )
+  })
+
+  it("損益率は小数点2桁に丸めて出力する", () => {
+    const holding: Holding = {
+      ...baseHolding,
+      unrealized_pl_percentage: 90.51679707632479,
+      total_pl_percentage: -47.794392523364486,
+    }
+    const csv = holdingsToCsv([holding])
+    const lines = csv.replace(BOM, "").split("\r\n")
+    const fields = lines[1].split(",")
+    expect(fields[5]).toBe("90.52")
+    expect(fields[9]).toBe("-47.79")
+  })
+
+  it("最終更新日時のマイクロ秒を削除する", () => {
+    const holding: Holding = { ...baseHolding, last_updated: "2026-05-02T07:40:00.882068+09:00" }
+    const csv = holdingsToCsv([holding])
+    expect(csv).toContain("2026-05-02T07:40:00+09:00")
+    expect(csv).not.toContain("882068")
   })
 
   it("数値フィールドがnullの場合は空文字で出力する", () => {

--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import type { Holding } from "./api/types"
+import { escapeCsvField, holdingsToCsv } from "./csv"
+
+const BOM = "﻿"
+
+const baseHolding: Holding = {
+  symbol: "7203",
+  quantity: 100,
+  average_cost: 2000,
+  total_cost: 200000,
+  current_price: 2500,
+  market_value: 250000,
+  realized_pl: 1000,
+  total_dividend: 500,
+  unrealized_pl: 50000,
+  unrealized_pl_percentage: 25,
+  total_pl: 51500,
+  total_pl_percentage: 25.75,
+  user_id: 1,
+  last_updated: "2026-05-01T10:00:00+09:00",
+  stock_name: "トヨタ自動車",
+  security_type: "stock",
+  currency: "JPY",
+}
+
+describe("escapeCsvField", () => {
+  it("通常の文字列はそのまま返す", () => {
+    expect(escapeCsvField("hello")).toBe("hello")
+  })
+
+  it("数値は文字列化して返す", () => {
+    expect(escapeCsvField(123.45)).toBe("123.45")
+  })
+
+  it("nullは空文字を返す", () => {
+    expect(escapeCsvField(null)).toBe("")
+  })
+
+  it("undefinedは空文字を返す", () => {
+    expect(escapeCsvField(undefined)).toBe("")
+  })
+
+  it("カンマを含む値はダブルクォートで囲む", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"')
+  })
+
+  it("改行を含む値はダブルクォートで囲む", () => {
+    expect(escapeCsvField("a\nb")).toBe('"a\nb"')
+  })
+
+  it("ダブルクォートを含む値はエスケープして囲む", () => {
+    expect(escapeCsvField('a"b')).toBe('"a""b"')
+  })
+})
+
+describe("holdingsToCsv", () => {
+  it("BOM始まり・CRLF区切りでヘッダー行を出力する", () => {
+    const csv = holdingsToCsv([])
+    expect(csv.startsWith(BOM)).toBe(true)
+    expect(csv).toBe(
+      `${BOM}銘柄コード,銘柄名,株数,評価額,含み損益,含み損益率,実現損益,受取配当金,合計損益,合計損益率,最終更新日時`
+    )
+  })
+
+  it("1件の保有データを期待通りの順で出力する", () => {
+    const csv = holdingsToCsv([baseHolding])
+    const lines = csv.replace(BOM, "").split("\r\n")
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toBe(
+      "7203,トヨタ自動車,100,250000,50000,25,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
+    )
+  })
+
+  it("数値フィールドがnullの場合は空文字で出力する", () => {
+    const holding: Holding = {
+      ...baseHolding,
+      market_value: null,
+      unrealized_pl: null,
+      unrealized_pl_percentage: null,
+      total_pl: null,
+      total_pl_percentage: null,
+      realized_pl: null,
+      total_dividend: null,
+      stock_name: null,
+    }
+    const csv = holdingsToCsv([holding])
+    const lines = csv.replace(BOM, "").split("\r\n")
+    expect(lines[1]).toBe("7203,,100,,,,,,,,2026-05-01T10:00:00+09:00")
+  })
+
+  it("銘柄名にカンマが含まれる場合はエスケープする", () => {
+    const holding: Holding = { ...baseHolding, stock_name: "Alphabet, Inc." }
+    const csv = holdingsToCsv([holding])
+    expect(csv).toContain('"Alphabet, Inc."')
+  })
+})

--- a/src/web/src/lib/csv.ts
+++ b/src/web/src/lib/csv.ts
@@ -23,9 +23,9 @@ export function escapeCsvField(value: string | number | null | undefined): strin
   return str
 }
 
-function formatPercent(value: number | null | undefined): string {
+function roundNumeric(value: number | null | undefined, digits: number): string {
   if (value === null || value === undefined) return ""
-  return value.toFixed(2)
+  return Number(value.toFixed(digits)).toString()
 }
 
 function stripMicroseconds(isoDate: string | null | undefined): string {
@@ -38,14 +38,14 @@ export function holdingsToCsv(holdings: Holding[]): string {
     [
       h.symbol,
       h.stock_name,
-      h.quantity,
-      h.market_value,
-      h.unrealized_pl,
-      formatPercent(h.unrealized_pl_percentage),
-      h.realized_pl,
-      h.total_dividend,
-      h.total_pl,
-      formatPercent(h.total_pl_percentage),
+      roundNumeric(h.quantity, 4),
+      roundNumeric(h.market_value, 2),
+      roundNumeric(h.unrealized_pl, 2),
+      roundNumeric(h.unrealized_pl_percentage, 2),
+      roundNumeric(h.realized_pl, 2),
+      roundNumeric(h.total_dividend, 2),
+      roundNumeric(h.total_pl, 2),
+      roundNumeric(h.total_pl_percentage, 2),
       stripMicroseconds(h.last_updated),
     ]
       .map(escapeCsvField)

--- a/src/web/src/lib/csv.ts
+++ b/src/web/src/lib/csv.ts
@@ -1,0 +1,59 @@
+import type { Holding } from "./api/types"
+
+const CSV_HEADERS = [
+  "銘柄コード",
+  "銘柄名",
+  "株数",
+  "評価額",
+  "含み損益",
+  "含み損益率",
+  "実現損益",
+  "受取配当金",
+  "合計損益",
+  "合計損益率",
+  "最終更新日時",
+] as const
+
+export function escapeCsvField(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return ""
+  const str = String(value)
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export function holdingsToCsv(holdings: Holding[]): string {
+  const rows = holdings.map((h) =>
+    [
+      h.symbol,
+      h.stock_name,
+      h.quantity,
+      h.market_value,
+      h.unrealized_pl,
+      h.unrealized_pl_percentage,
+      h.realized_pl,
+      h.total_dividend,
+      h.total_pl,
+      h.total_pl_percentage,
+      h.last_updated,
+    ]
+      .map(escapeCsvField)
+      .join(",")
+  )
+
+  const lines = [CSV_HEADERS.join(","), ...rows]
+  return `﻿${lines.join("\r\n")}`
+}
+
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/src/web/src/lib/csv.ts
+++ b/src/web/src/lib/csv.ts
@@ -23,6 +23,16 @@ export function escapeCsvField(value: string | number | null | undefined): strin
   return str
 }
 
+function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined) return ""
+  return value.toFixed(2)
+}
+
+function stripMicroseconds(isoDate: string | null | undefined): string {
+  if (!isoDate) return ""
+  return isoDate.replace(/\.\d+(?=[+\-Z])/, "")
+}
+
 export function holdingsToCsv(holdings: Holding[]): string {
   const rows = holdings.map((h) =>
     [
@@ -31,12 +41,12 @@ export function holdingsToCsv(holdings: Holding[]): string {
       h.quantity,
       h.market_value,
       h.unrealized_pl,
-      h.unrealized_pl_percentage,
+      formatPercent(h.unrealized_pl_percentage),
       h.realized_pl,
       h.total_dividend,
       h.total_pl,
-      h.total_pl_percentage,
-      h.last_updated,
+      formatPercent(h.total_pl_percentage),
+      stripMicroseconds(h.last_updated),
     ]
       .map(escapeCsvField)
       .join(",")

--- a/src/web/src/routes/Holdings.tsx
+++ b/src/web/src/routes/Holdings.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw } from "lucide-react"
+import { Download, RefreshCw } from "lucide-react"
 import useSWR from "swr"
 import { HoldingAllocationChart } from "@/components/dashboard/holding-allocation-chart"
 import { HoldingsTable } from "@/components/dashboard/holdings-table"
@@ -6,6 +6,7 @@ import { SecurityTypeChart } from "@/components/dashboard/security-type-chart"
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout"
 import { Button } from "@/components/ui/button"
 import { getHoldings } from "@/lib/api/client"
+import { downloadCsv, holdingsToCsv } from "@/lib/csv"
 import { useAuthStore } from "@/lib/stores/auth-store"
 
 export default function Holdings() {
@@ -21,15 +22,32 @@ export default function Holdings() {
     mutate()
   }
 
+  const handleExport = () => {
+    if (!holdings) return
+    const activeHoldings = holdings.filter((h) => h.quantity > 0)
+    if (activeHoldings.length === 0) return
+    const now = new Date()
+    const yyyymmdd = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}`
+    downloadCsv(`holdings_${yyyymmdd}.csv`, holdingsToCsv(activeHoldings))
+  }
+
+  const exportDisabled = isLoading || !holdings || holdings.filter((h) => h.quantity > 0).length === 0
+
   return (
     <AuthenticatedLayout>
       <div className="mx-auto max-w-7xl space-y-6 p-4 md:p-6">
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">保有状況</h2>
-          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isLoading}>
-            <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handleExport} disabled={exportDisabled}>
+              <Download className="h-4 w-4" />
+              CSVエクスポート
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isLoading}>
+              <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
         </div>
         <SecurityTypeChart data={holdings} isLoading={isLoading} />
         <HoldingAllocationChart data={holdings} isLoading={isLoading} />

--- a/src/web/src/routes/Holdings.tsx
+++ b/src/web/src/routes/Holdings.tsx
@@ -22,16 +22,15 @@ export default function Holdings() {
     mutate()
   }
 
+  const activeHoldings = holdings?.filter((h) => h.quantity > 0) ?? []
+  const exportDisabled = isLoading || activeHoldings.length === 0
+
   const handleExport = () => {
-    if (!holdings) return
-    const activeHoldings = holdings.filter((h) => h.quantity > 0)
     if (activeHoldings.length === 0) return
     const now = new Date()
     const yyyymmdd = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}`
     downloadCsv(`holdings_${yyyymmdd}.csv`, holdingsToCsv(activeHoldings))
   }
-
-  const exportDisabled = isLoading || !holdings || holdings.filter((h) => h.quantity > 0).length === 0
 
   return (
     <AuthenticatedLayout>


### PR DESCRIPTION
ポートフォリオ分析のために保有銘柄をCSVダウンロードできるようにする。
保有中(quantity>0)のみを対象とし、UTF-8 BOM付きでExcelでも文字化けしない。

https://claude.ai/code/session_01FfjMyaM8y99pdctvu759Mo