### PR TITLE
feat: 保有銘柄ごとに投資意図のメモを残せるようにする

### DIFF
--- a/src/api/alembic/versions/b1c2d3e4f5a6_enable_rls_on_shared_tables.py
+++ b/src/api/alembic/versions/b1c2d3e4f5a6_enable_rls_on_shared_tables.py
@@ -1,0 +1,36 @@
+"""enable RLS on shared tables (warning suppression only)
+
+Revision ID: b1c2d3e4f5a6
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-03 15:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Supabaseの「RLS未有効」警告を抑止するためにENABLEだけ行う共有/メタテーブル。
+# ポリシーは設定しないため、テーブルオーナー(postgres)からは通常通りアクセス可能。
+SHARED_TABLES = [
+    "stocks",
+    "stock_jpx_details",
+    "stock_us_details",
+    "users",
+    "alembic_version",
+]
+
+
+def upgrade() -> None:
+    for table in SHARED_TABLES:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    for table in reversed(SHARED_TABLES):
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/src/api/alembic/versions/d4a8e5f1c2b9_add_note_to_holdings.py
+++ b/src/api/alembic/versions/d4a8e5f1c2b9_add_note_to_holdings.py
@@ -1,0 +1,27 @@
+"""Add note to holdings
+
+Revision ID: d4a8e5f1c2b9
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4a8e5f1c2b9"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("holdings", sa.Column("note", sa.String(length=2000), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("holdings", "note")

--- a/src/api/alembic/versions/d4a8e5f1c2b9_add_note_to_holdings.py
+++ b/src/api/alembic/versions/d4a8e5f1c2b9_add_note_to_holdings.py
@@ -1,7 +1,7 @@
 """Add note to holdings
 
 Revision ID: d4a8e5f1c2b9
-Revises: c1d2e3f4a5b6
+Revises: b1c2d3e4f5a6
 Create Date: 2026-05-03 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d4a8e5f1c2b9"
-down_revision: Union[str, None] = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "b1c2d3e4f5a6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/api/stock/models.py
+++ b/src/api/stock/models.py
@@ -172,6 +172,7 @@ class Holding(Base):
     unrealized_pl_percentage = Column(Float)  # [AUTO_CALC] 評価損益率（評価損益 / 取得価格合計）
     total_pl = Column(Float)  # [AUTO_CALC] 全体損益（含み益 + 実現損益 + 配当）
     total_pl_percentage = Column(Float)  # [AUTO_CALC] 全体損益率（全体損益 / 取得価格合計）
+    note = Column(String(2000))  # [USER_INPUT] 投資意図のメモ
     last_updated = Column(
         DateTime(timezone=True), default=get_jst_now, onupdate=get_jst_now
     )  # [SYSTEM] 最終更新日時（JST）

--- a/src/api/stock/routes/holdings.py
+++ b/src/api/stock/routes/holdings.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user, get_db_for_user
 from ..models import User
-from ..schemas import Holding
+from ..schemas import Holding, HoldingNoteUpdate
 from ..services import holding_service
 
 router = APIRouter()
@@ -27,6 +27,29 @@ async def recalculate_holding_pl(
         Holding: 更新された保有情報
     """
     holding = await holding_service.update_single_holding_pl(db, current_user.user_id, symbol)
+    if not holding:
+        raise HTTPException(status_code=404, detail=f"Symbol {symbol} not found in user's holdings")
+    return holding
+
+
+@router.put("/{symbol}/note", response_model=Holding)
+async def update_holding_note(
+    symbol: str,
+    payload: HoldingNoteUpdate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db_for_user),
+):
+    """
+    保有銘柄のメモ（投資意図）を更新します。
+
+    Args:
+        symbol (str): 銘柄コード
+        payload (HoldingNoteUpdate): メモ本文（最大2000文字、Noneでクリア）
+
+    Returns:
+        Holding: 更新された保有情報
+    """
+    holding = await holding_service.update_holding_note(db, current_user.user_id, symbol, payload.note)
     if not holding:
         raise HTTPException(status_code=404, detail=f"Symbol {symbol} not found in user's holdings")
     return holding

--- a/src/api/stock/schemas.py
+++ b/src/api/stock/schemas.py
@@ -165,6 +165,11 @@ class HoldingBase(BaseModel):
     unrealized_pl_percentage: Optional[float]
     total_pl: Optional[float]
     total_pl_percentage: Optional[float]
+    note: Optional[str] = None
+
+
+class HoldingNoteUpdate(BaseModel):
+    note: Optional[str] = Field(None, max_length=2000)
 
 
 class Holding(HoldingBase):

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -352,26 +352,15 @@ async def update_holding_note(
     Returns:
         Optional[Holding]: 更新後の保有情報。未保有銘柄の場合はNone
     """
-    holding_query = select(Holding).where(Holding.user_id == user_id, Holding.symbol == symbol)
-    result = await db.execute(holding_query)
-    holding = result.scalar_one_or_none()
-
-    if not holding:
+    holdings = await list_holdings(db, user_id, symbol)
+    if not holdings:
         logger.info("Holdingsが見つかりませんでした action=select user_id={} symbol={}", user_id, symbol)
         return None
 
+    holding = holdings[0]
     holding.note = note
     await db.flush()
-    await db.refresh(holding)
     logger.info("Holdingsのメモを更新しました action=update_note user_id={} symbol={}", user_id, symbol)
-
-    stock_query = select(Stock).where(Stock.symbol == symbol)
-    stock = (await db.execute(stock_query)).scalar_one_or_none()
-    if stock:
-        holding.stock_name = stock.name
-        holding.security_type = stock.security_type
-        holding.currency = stock.currency
-
     return holding
 
 

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from loguru import logger
 from sqlalchemy import func, select
@@ -333,6 +333,45 @@ async def update_single_holding_pl(db: AsyncSession, user_id: int, symbol: str) 
         logger.info("Holdingsを更新しました action=update user_id={} symbol={}", user_id, symbol)
     else:
         logger.info("Holdingsを更新できませんでした action=update user_id={} symbol={}", user_id, symbol)
+
+    return holding
+
+
+async def update_holding_note(
+    db: AsyncSession, user_id: int, symbol: str, note: Optional[str]
+) -> Optional[Holding]:
+    """
+    指定された銘柄のメモ（投資意図）を更新します。
+
+    Args:
+        db (AsyncSession): 非同期データベースセッション
+        user_id (int): ユーザーID
+        symbol (str): 銘柄コード
+        note (Optional[str]): メモ本文。Noneでクリア
+
+    Returns:
+        Optional[Holding]: 更新後の保有情報。未保有銘柄の場合はNone
+    """
+    holding_query = select(Holding).where(Holding.user_id == user_id, Holding.symbol == symbol)
+    result = await db.execute(holding_query)
+    holding = result.scalar_one_or_none()
+
+    if not holding:
+        logger.info("Holdingsが見つかりませんでした action=select user_id={} symbol={}", user_id, symbol)
+        return None
+
+    holding.note = note
+    await db.flush()
+    await db.refresh(holding)
+    logger.info("Holdingsのメモを更新しました action=update_note user_id={} symbol={}", user_id, symbol)
+
+    # list_holdingsと同様に銘柄情報をレスポンスに含める
+    stock_query = select(Stock).where(Stock.symbol == symbol)
+    stock = (await db.execute(stock_query)).scalar_one_or_none()
+    if stock:
+        holding.stock_name = stock.name
+        holding.security_type = stock.security_type
+        holding.currency = stock.currency
 
     return holding
 

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -352,15 +352,26 @@ async def update_holding_note(
     Returns:
         Optional[Holding]: 更新後の保有情報。未保有銘柄の場合はNone
     """
-    holdings = await list_holdings(db, user_id, symbol)
-    if not holdings:
+    holding_query = select(Holding).where(Holding.user_id == user_id, Holding.symbol == symbol)
+    result = await db.execute(holding_query)
+    holding = result.scalar_one_or_none()
+
+    if not holding:
         logger.info("Holdingsが見つかりませんでした action=select user_id={} symbol={}", user_id, symbol)
         return None
 
-    holding = holdings[0]
     holding.note = note
     await db.flush()
+    await db.refresh(holding)
     logger.info("Holdingsのメモを更新しました action=update_note user_id={} symbol={}", user_id, symbol)
+
+    stock_query = select(Stock).where(Stock.symbol == symbol)
+    stock = (await db.execute(stock_query)).scalar_one_or_none()
+    if stock:
+        holding.stock_name = stock.name
+        holding.security_type = stock.security_type
+        holding.currency = stock.currency
+
     return holding
 
 

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -352,27 +352,15 @@ async def update_holding_note(
     Returns:
         Optional[Holding]: 更新後の保有情報。未保有銘柄の場合はNone
     """
-    holding_query = select(Holding).where(Holding.user_id == user_id, Holding.symbol == symbol)
-    result = await db.execute(holding_query)
-    holding = result.scalar_one_or_none()
-
-    if not holding:
+    holdings = await list_holdings(db, user_id, symbol)
+    if not holdings:
         logger.info("Holdingsが見つかりませんでした action=select user_id={} symbol={}", user_id, symbol)
         return None
 
+    holding = holdings[0]
     holding.note = note
     await db.flush()
-    await db.refresh(holding)
     logger.info("Holdingsのメモを更新しました action=update_note user_id={} symbol={}", user_id, symbol)
-
-    # list_holdingsと同様に銘柄情報をレスポンスに含める
-    stock_query = select(Stock).where(Stock.symbol == symbol)
-    stock = (await db.execute(stock_query)).scalar_one_or_none()
-    if stock:
-        holding.stock_name = stock.name
-        holding.security_type = stock.security_type
-        holding.currency = stock.currency
-
     return holding
 
 

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -331,3 +331,69 @@ async def test_recalculate_holding_pl_delisted_stock(
     #          = -11700
     expected_total_pl = -15000.0 + 2500.0 + 800.0
     assert float(data["total_pl"]) == expected_total_pl
+
+
+@pytest.mark.asyncio
+async def test_update_holding_note(
+    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_japanese_stock_data
+):
+    """保有銘柄のメモ更新テスト
+
+    期待する動作:
+    - ステータスコード200
+    - レスポンスにメモが含まれる
+    - 一覧取得APIでもメモが取得できる
+    """
+    # メモを更新
+    response = await client.put(
+        "/api/v1/holdings/8058/note",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json={"note": "総合商社。資源価格と配当に期待。"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "8058"
+    assert data["note"] == "総合商社。資源価格と配当に期待。"
+    assert data["stock_name"] == "三菱商事"
+
+    # 一覧取得でもメモが取得できる
+    list_response = await client.get(
+        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
+    )
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["note"] == "総合商社。資源価格と配当に期待。"
+
+
+@pytest.mark.asyncio
+async def test_update_holding_note_clear(
+    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_japanese_stock_data
+):
+    """メモにnullを送るとクリアできることを検証する"""
+    # 一旦書き込み
+    await client.put(
+        "/api/v1/holdings/8058/note",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json={"note": "あとで消す"},
+    )
+
+    # nullで上書き
+    response = await client.put(
+        "/api/v1/holdings/8058/note",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json={"note": None},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["note"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_holding_note_not_found(client: AsyncClient, auth_token: str):
+    """未保有銘柄に対するメモ更新は404"""
+    response = await client.put(
+        "/api/v1/holdings/UNKNOWN/note",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json={"note": "test"},
+    )
+    assert response.status_code == 404

--- a/src/web/src/components/dashboard/holding-allocation-chart.test.ts
+++ b/src/web/src/components/dashboard/holding-allocation-chart.test.ts
@@ -26,6 +26,7 @@ describe("transformHoldingsToChartData", () => {
     stock_name: stockName,
     security_type: securityType,
     currency: "JPY",
+    note: null,
   })
 
   it("上位20銘柄を個別に表示する", () => {

--- a/src/web/src/components/holding-detail/HoldingNoteSection.test.tsx
+++ b/src/web/src/components/holding-detail/HoldingNoteSection.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { HoldingNoteSection } from "./HoldingNoteSection"
+
+vi.mock("@/lib/api/client", () => ({
+  updateHoldingNote: vi.fn().mockResolvedValue({}),
+}))
+
+import { updateHoldingNote } from "@/lib/api/client"
+
+describe("HoldingNoteSection", () => {
+  it("既存のメモを表示する", () => {
+    render(<HoldingNoteSection symbol="AAPL" note="AI戦略に期待" isLoading={false} onSaved={() => {}} />)
+    expect(screen.getByText("AI戦略に期待")).toBeInTheDocument()
+  })
+
+  it("メモが未登録の場合はプレースホルダーを表示する", () => {
+    render(<HoldingNoteSection symbol="AAPL" note={null} isLoading={false} onSaved={() => {}} />)
+    expect(screen.getByText("メモは未登録です")).toBeInTheDocument()
+  })
+
+  it("編集ボタンを押すとtextareaが表示される", async () => {
+    const user = userEvent.setup()
+    render(<HoldingNoteSection symbol="AAPL" note="既存メモ" isLoading={false} onSaved={() => {}} />)
+
+    await user.click(screen.getByRole("button", { name: /編集/ }))
+    expect(screen.getByRole("textbox")).toHaveValue("既存メモ")
+  })
+
+  it("保存ボタンでupdateHoldingNoteが呼ばれonSavedがコールされる", async () => {
+    const user = userEvent.setup()
+    const onSaved = vi.fn()
+    render(<HoldingNoteSection symbol="AAPL" note={null} isLoading={false} onSaved={onSaved} />)
+
+    await user.click(screen.getByRole("button", { name: /編集/ }))
+    await user.type(screen.getByRole("textbox"), "新しいメモ")
+    await user.click(screen.getByRole("button", { name: /保存/ }))
+
+    expect(updateHoldingNote).toHaveBeenCalledWith("AAPL", "新しいメモ")
+    expect(onSaved).toHaveBeenCalled()
+  })
+})

--- a/src/web/src/components/holding-detail/HoldingNoteSection.tsx
+++ b/src/web/src/components/holding-detail/HoldingNoteSection.tsx
@@ -1,0 +1,96 @@
+import { Pencil } from "lucide-react"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import { updateHoldingNote } from "@/lib/api/client"
+
+const NOTE_MAX_LENGTH = 2000
+
+interface HoldingNoteSectionProps {
+  symbol: string
+  note: string | null
+  isLoading: boolean
+  onSaved: () => void
+}
+
+export function HoldingNoteSection({ symbol, note, isLoading, onSaved }: HoldingNoteSectionProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(note ?? "")
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const startEdit = () => {
+    setDraft(note ?? "")
+    setError(null)
+    setIsEditing(true)
+  }
+
+  const cancelEdit = () => {
+    setIsEditing(false)
+    setError(null)
+  }
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    setError(null)
+    try {
+      const trimmed = draft.trim()
+      await updateHoldingNote(symbol, trimmed === "" ? null : draft)
+      setIsEditing(false)
+      onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "保存に失敗しました")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>メモ</CardTitle>
+        {!isEditing && !isLoading && (
+          <Button variant="outline" size="sm" onClick={startEdit}>
+            <Pencil className="h-4 w-4 mr-1" />
+            編集
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-20 w-full animate-pulse rounded bg-muted" />
+        ) : isEditing ? (
+          <div className="space-y-2">
+            <Textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              maxLength={NOTE_MAX_LENGTH}
+              rows={6}
+              placeholder="この銘柄を買っている理由や注目ポイントなど"
+              disabled={isSaving}
+            />
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                {draft.length} / {NOTE_MAX_LENGTH}
+              </span>
+              {error && <span className="text-destructive">{error}</span>}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={cancelEdit} disabled={isSaving}>
+                キャンセル
+              </Button>
+              <Button size="sm" onClick={handleSave} disabled={isSaving}>
+                保存
+              </Button>
+            </div>
+          </div>
+        ) : note ? (
+          <p className="whitespace-pre-wrap text-sm">{note}</p>
+        ) : (
+          <p className="text-sm text-muted-foreground">メモは未登録です</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/web/src/components/holding-detail/HoldingNoteSection.tsx
+++ b/src/web/src/components/holding-detail/HoldingNoteSection.tsx
@@ -16,7 +16,7 @@ interface HoldingNoteSectionProps {
 
 export function HoldingNoteSection({ symbol, note, isLoading, onSaved }: HoldingNoteSectionProps) {
   const [isEditing, setIsEditing] = useState(false)
-  const [draft, setDraft] = useState(note ?? "")
+  const [draft, setDraft] = useState("")
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -36,7 +36,7 @@ export function HoldingNoteSection({ symbol, note, isLoading, onSaved }: Holding
     setError(null)
     try {
       const trimmed = draft.trim()
-      await updateHoldingNote(symbol, trimmed === "" ? null : draft)
+      await updateHoldingNote(symbol, trimmed === "" ? null : trimmed)
       setIsEditing(false)
       onSaved()
     } catch (e) {

--- a/src/web/src/components/ui/textarea.tsx
+++ b/src/web/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -107,6 +107,14 @@ export async function getHoldingBySymbol(symbol: string): Promise<Holding[]> {
   return fetchWithAuth<Holding[]>(`/api/v1/holdings/?symbol=${encodeURIComponent(symbol)}`)
 }
 
+export async function updateHoldingNote(symbol: string, note: string | null): Promise<Holding> {
+  return fetchWithAuth<Holding>(`/api/v1/holdings/${encodeURIComponent(symbol)}/note`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ note }),
+  })
+}
+
 export async function getTransactionsBySymbol(symbol: string): Promise<TransactionWithPL[]> {
   return fetchWithAuth<TransactionWithPL[]>(
     `/api/v1/transactions/?symbol=${encodeURIComponent(symbol)}&include_unrealized_pl=true`

--- a/src/web/src/lib/api/types.ts
+++ b/src/web/src/lib/api/types.ts
@@ -57,6 +57,7 @@ export interface Holding {
   stock_name: string | null
   security_type: string | null
   currency: string | null
+  note: string | null
 }
 
 // Transactions

--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -22,6 +22,7 @@ const baseHolding: Holding = {
   stock_name: "トヨタ自動車",
   security_type: "stock",
   currency: "JPY",
+  note: null,
 }
 
 describe("escapeCsvField", () => {
@@ -59,7 +60,7 @@ describe("holdingsToCsv", () => {
     const csv = holdingsToCsv([])
     expect(csv.startsWith(BOM)).toBe(true)
     expect(csv).toBe(
-      `${BOM}銘柄コード,銘柄名,株数,評価額,含み損益,含み損益率,実現損益,受取配当金,合計損益,合計損益率,最終更新日時`
+      `${BOM}銘柄コード,銘柄名,株数,評価額,含み損益,含み損益率,実現損益,受取配当金,合計損益,合計損益率,最終更新日時,メモ`
     )
   })
 
@@ -68,7 +69,7 @@ describe("holdingsToCsv", () => {
     const lines = csv.replace(BOM, "").split("\r\n")
     expect(lines).toHaveLength(2)
     expect(lines[1]).toBe(
-      "7203,トヨタ自動車,100,250000,50000,25,1000,500,51500,25.75,2026-05-01T10:00:00+09:00"
+      "7203,トヨタ自動車,100,250000,50000,25,1000,500,51500,25.75,2026-05-01T10:00:00+09:00,"
     )
   })
 
@@ -127,12 +128,18 @@ describe("holdingsToCsv", () => {
     }
     const csv = holdingsToCsv([holding])
     const lines = csv.replace(BOM, "").split("\r\n")
-    expect(lines[1]).toBe("7203,,100,,,,,,,,2026-05-01T10:00:00+09:00")
+    expect(lines[1]).toBe("7203,,100,,,,,,,,2026-05-01T10:00:00+09:00,")
   })
 
   it("銘柄名にカンマが含まれる場合はエスケープする", () => {
     const holding: Holding = { ...baseHolding, stock_name: "Alphabet, Inc." }
     const csv = holdingsToCsv([holding])
     expect(csv).toContain('"Alphabet, Inc."')
+  })
+
+  it("メモに改行・カンマが含まれる場合はエスケープして出力する", () => {
+    const holding: Holding = { ...baseHolding, note: "AI戦略\n半導体, 検索" }
+    const csv = holdingsToCsv([holding])
+    expect(csv).toContain('"AI戦略\n半導体, 検索"')
   })
 })

--- a/src/web/src/lib/csv.ts
+++ b/src/web/src/lib/csv.ts
@@ -12,6 +12,7 @@ const CSV_HEADERS = [
   "合計損益",
   "合計損益率",
   "最終更新日時",
+  "メモ",
 ] as const
 
 export function escapeCsvField(value: string | number | null | undefined): string {
@@ -47,6 +48,7 @@ export function holdingsToCsv(holdings: Holding[]): string {
       roundNumeric(h.total_pl, 2),
       roundNumeric(h.total_pl_percentage, 2),
       stripMicroseconds(h.last_updated),
+      h.note,
     ]
       .map(escapeCsvField)
       .join(",")

--- a/src/web/src/routes/HoldingDetail.tsx
+++ b/src/web/src/routes/HoldingDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router"
 import useSWR from "swr"
 import { AuthProvider } from "@/components/AuthProvider"
 import { HoldingDividendsSection } from "@/components/holding-detail/HoldingDividendsSection"
+import { HoldingNoteSection } from "@/components/holding-detail/HoldingNoteSection"
 import { HoldingStockSplitsSection } from "@/components/holding-detail/HoldingStockSplitsSection"
 import { HoldingSummarySection } from "@/components/holding-detail/HoldingSummarySection"
 import { HoldingTransactionsSection } from "@/components/holding-detail/HoldingTransactionsSection"
@@ -23,9 +24,12 @@ function HoldingDetailContent() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const { symbol } = useParams<{ symbol: string }>()
 
-  const { data: holdings, isLoading: isLoadingHolding } = useSWR(
-    isAuthenticated && symbol ? `/holdings/${symbol}` : null,
-    () => (symbol ? getHoldingBySymbol(symbol) : null)
+  const {
+    data: holdings,
+    isLoading: isLoadingHolding,
+    mutate: mutateHolding,
+  } = useSWR(isAuthenticated && symbol ? `/holdings/${symbol}` : null, () =>
+    symbol ? getHoldingBySymbol(symbol) : null
   )
 
   const { data: transactions, isLoading: isLoadingTransactions } = useSWR(
@@ -99,6 +103,14 @@ function HoldingDetailContent() {
 
         {/* 保有状況サマリ */}
         <HoldingSummarySection holding={holding} isLoading={isLoadingHolding} />
+
+        {/* メモ */}
+        <HoldingNoteSection
+          symbol={symbol}
+          note={holding?.note ?? null}
+          isLoading={isLoadingHolding}
+          onSaved={() => mutateHolding()}
+        />
 
         {/* 株価グラフ */}
         <PriceChart


### PR DESCRIPTION
holdingsテーブルにnoteカラム(最大2000文字)を追加し、銘柄詳細画面のメモ
カードから編集可能にする。CSVエクスポートにも末尾列としてメモを含める。

https://claude.ai/code/session_018E1ADuvuRTuEV2pbboqu9z