### PR TITLE
refactor(api): Bearer認証を撤去しCookie認証に一本化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,13 +175,14 @@ uv run alembic downgrade -1
 
 ### 認証認可
 
+Cookie(httponly) ベースの認証に一本化。`/api/v1/token` がログイン成功時にCookieをセットし、以降のAPIリクエストはCookieで認証する。定期ジョブはGoogle Cloud Run JobsでDB直結のため、HTTP経由のAPI認証経路は持たない。
+
 想定クライアントは以下
 
 | クライアント | 認証方法 | 用途 |
 |-------------|---------|------|
 | Webフロントエンド | Cookie(httponly) | ブラウザからのアクセス |
-| ユーザー端末からの直接API呼び出し | Authorization ヘッダー | スクリプトや CLI からのアクセス |
-| Swagger UI (/docs) | OAuth2形式 | API テスト・開発 |
+| Swagger UI (/docs) | Cookie(httponly) | `/api/v1/token` を Try it out でログイン後、Cookieが自動付与される |
 
 ### パスワードハッシュ
 

--- a/src/api/docs/testing-guide.md
+++ b/src/api/docs/testing-guide.md
@@ -27,9 +27,9 @@
 
 ### 認証
 
-- 一般ユーザー: `auth_token` フィクスチャ（username: "testuser"）
-- 管理者ユーザー: `auth_admin_token` フィクスチャ（username: "adminuser"）
-- APIリクエストには `headers={"Authorization": f"Bearer {auth_token}"}` を指定
+- 一般ユーザー: `auth_token` フィクスチャ（username: "testuser"、副作用としてclientにCookieをセット）
+- 管理者ユーザー: `auth_admin_token` フィクスチャ（username: "adminuser"、副作用としてclientにCookieをセット）
+- フィクスチャを引数で受け取るだけで認証済みとなる（`headers` の明示指定は不要）
 
 ### 外部APIのモック
 

--- a/src/api/stock/auth.py
+++ b/src/api/stock/auth.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Annotated, AsyncGenerator
 
-from fastapi import Cookie, Depends, Header, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Cookie, Depends, HTTPException, status
 from jose import JWTError, jwt
 from loguru import logger
 from pwdlib import PasswordHash
@@ -20,9 +19,6 @@ SECRET_KEY = settings.JWT_SECRET_KEY
 # アルゴリズムとトークン有効期限は固定値として定義
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 1日
-
-# OAuth2スキームを更新してOAuthエンドポイントを指すように
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/oauth/token")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -101,48 +97,31 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
 
 
 async def get_current_user(
-    access_token_cookie: Annotated[str | None, Cookie(alias="token")] = None,
-    authorization: Annotated[str | None, Header()] = None,
+    token: Annotated[str | None, Cookie()] = None,
     db: AsyncSession = Depends(get_db),
 ) -> schemas.User:
     """
-    現在のユーザーを取得する。以下の順序で認証を試みる：
-    1. Bearerトークン（OAuth2）
-    2. クッキーのアクセストークン
-    3. Authorizationヘッダー
+    現在のユーザーをCookie認証で取得する
+    - token: Cookieに格納されたJWT
+    - 認証失敗時: 401 Unauthorized
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
     )
 
-    jwt_token = None  # 初期化して未定義エラーを防止
-
-    if access_token_cookie:  # if に変更
-        # クッキーからトークンを取得（Bearerプレフィックスがある場合は削除）
-        if access_token_cookie.startswith("Bearer "):
-            jwt_token = access_token_cookie.replace("Bearer ", "")
-        else:
-            jwt_token = access_token_cookie
-    elif authorization and authorization.startswith("Bearer "):
-        jwt_token = authorization.replace("Bearer ", "")
-    else:
+    if not token:
         raise credentials_exception
 
     try:
-        if not jwt_token:
-            raise credentials_exception
-
-        payload = jwt.decode(jwt_token, SECRET_KEY, algorithms=[ALGORITHM])
-        username: str = payload.get("sub")
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
         if username is None:
             raise credentials_exception
-        token_data = schemas.TokenData(username=username)
     except JWTError:
         raise credentials_exception
 
-    user = await get_user(db, username=token_data.username)
+    user = await get_user(db, username=username)
     if user is None:
         raise credentials_exception
     return user

--- a/src/api/stock/auth.py
+++ b/src/api/stock/auth.py
@@ -11,12 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from . import models, schemas
 from .database import get_db, set_rls_user_id, settings
 
-# パスワードハッシュ化のための設定（Argon2id）
 password_hash = PasswordHash.recommended()
 
-# JWT設定
 SECRET_KEY = settings.JWT_SECRET_KEY
-# アルゴリズムとトークン有効期限は固定値として定義
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 1日
 

--- a/src/api/stock/routes/auth.py
+++ b/src/api/stock/routes/auth.py
@@ -2,7 +2,6 @@ import os
 
 from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from fastapi.security import OAuth2PasswordRequestForm
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -34,7 +33,6 @@ async def login_for_access_token(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
         )
 
     access_token = create_access_token(data={"sub": user.username})
@@ -51,31 +49,6 @@ async def login_for_access_token(
         path="/",
     )
     logger.info("Authトークンを発行しました action=create user_id={}", user.user_id)
-    return {"access_token": access_token, "token_type": "bearer"}
-
-
-@router.post("/oauth/token", response_model=Token)
-async def login_for_access_token_oauth(
-    form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)
-):
-    """
-    OAuth2形式でログイントークンを取得する（/docsでの認証用）
-    - form_data: ユーザー名とパスワード（application/x-www-form-urlencoded形式）
-    - 認証成功時: アクセストークンを返却
-    - 認証失敗時: 401 Unauthorized
-
-    このエンドポイントはFastAPIの/docsページの「authorize」ボタンで使用するための最小限の実装です。
-    """
-    user = await authenticate_user(db, form_data.username, form_data.password)
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    access_token = create_access_token(data={"sub": user.username})
-
-    # シンプルなトークンレスポンスのみを返す
     return {"access_token": access_token, "token_type": "bearer"}
 
 

--- a/src/api/stock/schemas.py
+++ b/src/api/stock/schemas.py
@@ -352,12 +352,6 @@ class Token(BaseModel):
     token_type: str = "bearer"
 
 
-class TokenData(BaseModel):
-    """JWTトークンデータ"""
-
-    username: str | None = None
-
-
 class StockCreate(BaseModel):
     """株式銘柄登録リクエスト"""
 

--- a/src/api/tests/api/test_datetime_jst_response.py
+++ b/src/api/tests/api/test_datetime_jst_response.py
@@ -30,9 +30,7 @@ async def test_transaction_response_datetime_is_jst(
         "transaction_date": "2024-06-15T10:30:00",  # naive datetime
     }
 
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     assert response.status_code == 200
     data = response.json()
@@ -69,12 +67,10 @@ async def test_transaction_list_response_datetime_is_jst(
         "tax": "0.0",
         "transaction_date": "2024-06-15T10:30:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 取引一覧を取得
-    response = await client.get("/api/v1/transactions/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/transactions/")
 
     assert response.status_code == 200
     data = response.json()
@@ -106,9 +102,7 @@ async def test_dividend_response_datetime_is_jst(
         "fee": "0.0",
     }
 
-    response = await client.post(
-        "/api/v1/dividends/", json=dividend_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/dividends/", json=dividend_data)
 
     assert response.status_code == 200
     data = response.json()
@@ -148,7 +142,7 @@ async def test_dividend_list_response_datetime_is_jst(
     await create_dividend(dividend_data)
 
     # 配当一覧を取得
-    response = await client.get("/api/v1/dividends/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/dividends/")
 
     assert response.status_code == 200
     data = response.json()
@@ -171,7 +165,7 @@ async def test_holdings_response_datetime_is_jst(
         setup_japanese_stock_data: 日本株のテストデータ
     """
     # 保有株一覧を取得
-    response = await client.get("/api/v1/holdings/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/holdings/")
 
     assert response.status_code == 200
     data = response.json()
@@ -207,15 +201,11 @@ async def test_transaction_monthly_summary_uses_jst(
         "transaction_date": "2024-12-01T00:00:00+09:00",  # JST
     }
 
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
     assert response.status_code == 200
 
     # 月次集計を取得
-    monthly_response = await client.get(
-        "/api/v1/transactions/monthly-summary", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    monthly_response = await client.get("/api/v1/transactions/monthly-summary")
     assert monthly_response.status_code == 200
     data = monthly_response.json()
 
@@ -254,15 +244,11 @@ async def test_transaction_yearly_summary_uses_jst(
         "transaction_date": "2024-01-01T00:00:00+09:00",  # JST
     }
 
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
     assert response.status_code == 200
 
     # 年次集計を取得
-    yearly_response = await client.get(
-        "/api/v1/transactions/yearly-summary", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    yearly_response = await client.get("/api/v1/transactions/yearly-summary")
     assert yearly_response.status_code == 200
     data = yearly_response.json()
 

--- a/src/api/tests/api/test_dividend.py
+++ b/src/api/tests/api/test_dividend.py
@@ -32,9 +32,7 @@ async def test_create_dividend(
         "fee": "0.0",
     }
 
-    response = await client.post(
-        "/api/v1/dividends/", json=dividend_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/dividends/", json=dividend_data)
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -50,9 +48,7 @@ async def test_create_dividend(
     assert float(data["fee"]) == float(dividend_data["fee"])
 
     # 保有情報の確認（配当金が反映されているか）
-    holdings_response = await client.get(
-        "/api/v1/holdings/", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
     holding = next((h for h in holdings if h["symbol"] == "8058"), None)
@@ -82,9 +78,7 @@ async def test_create_dividend_stock_not_found(client: AsyncClient, auth_token: 
         "fee": "0.0",
     }
 
-    response = await client.post(
-        "/api/v1/dividends/", json=dividend_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/dividends/", json=dividend_data)
 
     # レスポンス検証
     assert response.status_code == 404
@@ -133,7 +127,7 @@ async def test_list_dividends(
         await create_dividend(dividend_data)
 
     # 配当一覧を取得
-    response = await client.get("/api/v1/dividends/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/dividends/")
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -168,9 +162,7 @@ async def test_get_monthly_dividends(client: AsyncClient, auth_token: str, setup
         setup_dividend_data: テスト用配当データ
     """
     # 月次配当金集計の取得
-    response = await client.get(
-        "/api/v1/dividends/monthly", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/dividends/monthly")
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -230,9 +222,7 @@ async def test_get_monthly_dividends_respects_jst_boundary(
     }
     await create_dividend(boundary_dividend)
 
-    response = await client.get(
-        "/api/v1/dividends/monthly", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/dividends/monthly")
     assert response.status_code == 200
     data = response.json()
 
@@ -273,7 +263,6 @@ async def test_get_monthly_dividends_fills_gaps(client: AsyncClient, auth_token:
 
     response = await client.get(
         "/api/v1/dividends/monthly",
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert response.status_code == 200
     data = response.json()

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -24,9 +24,7 @@ async def test_recalculate_holding_pl_japanese_stock(
         setup_japanese_stock_data: 日本株のテストデータ
     """
     # 保有損益再計算APIを呼び出し
-    response = await client.post(
-        "/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/holdings/8058/recalculate")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -59,9 +57,7 @@ async def test_recalculate_holding_pl_us_stock(
         mock_external_apis: モック化されたAPI
     """
     # 保有損益再計算APIを呼び出し
-    response = await client.post(
-        "/api/v1/holdings/AAPL/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/holdings/AAPL/recalculate")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -95,7 +91,7 @@ async def test_list_holdings(
         setup_japanese_stock_data: 日本株のテストデータ
     """
     # 保有銘柄一覧を取得
-    response = await client.get("/api/v1/holdings/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/holdings/")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -129,9 +125,7 @@ async def test_recalculate_all_holdings_pl(
         setup_us_stock_data: 米国株のテストデータ
     """
     # 全銘柄の損益再計算APIを呼び出し
-    response = await client.post(
-        "/api/v1/holdings/recalculate-all", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/holdings/recalculate-all")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -211,9 +205,7 @@ async def test_recalculate_holding_pl_updates_realized_pl(
     await db_session.commit()
 
     # 再計算APIを呼び出し、実現損益が更新されることを確認
-    response = await client.post(
-        "/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/holdings/8058/recalculate")
     assert response.status_code == 200
     data = response.json()
     assert float(data["realized_pl"]) == 2500.0
@@ -288,9 +280,7 @@ async def test_recalculate_holding_pl_delisted_stock(
     )
 
     # 株価取得が0を返す状態で保有損益を再計算
-    response = await client.post(
-        "/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/holdings/8058/recalculate")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -347,7 +337,6 @@ async def test_update_holding_note(
     # メモを更新
     response = await client.put(
         "/api/v1/holdings/8058/note",
-        headers={"Authorization": f"Bearer {auth_token}"},
         json={"note": "総合商社。資源価格と配当に期待。"},
     )
 
@@ -358,9 +347,7 @@ async def test_update_holding_note(
     assert data["stock_name"] == "三菱商事"
 
     # 一覧取得でもメモが取得できる
-    list_response = await client.get(
-        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    list_response = await client.get("/api/v1/holdings/?symbol=8058")
     assert list_response.status_code == 200
     assert list_response.json()[0]["note"] == "総合商社。資源価格と配当に期待。"
 
@@ -373,14 +360,12 @@ async def test_update_holding_note_clear(
     # 一旦書き込み
     await client.put(
         "/api/v1/holdings/8058/note",
-        headers={"Authorization": f"Bearer {auth_token}"},
         json={"note": "あとで消す"},
     )
 
     # nullで上書き
     response = await client.put(
         "/api/v1/holdings/8058/note",
-        headers={"Authorization": f"Bearer {auth_token}"},
         json={"note": None},
     )
 
@@ -393,7 +378,6 @@ async def test_update_holding_note_not_found(client: AsyncClient, auth_token: st
     """未保有銘柄に対するメモ更新は404"""
     response = await client.put(
         "/api/v1/holdings/UNKNOWN/note",
-        headers={"Authorization": f"Bearer {auth_token}"},
         json={"note": "test"},
     )
     assert response.status_code == 404

--- a/src/api/tests/api/test_portfolio.py
+++ b/src/api/tests/api/test_portfolio.py
@@ -55,9 +55,7 @@ async def test_get_portfolio_summary(client, auth_token, setup_portfolio_test_da
         setup_portfolio_test_data: テストデータ準備用フィクスチャー
     """
     # APIリクエスト実行
-    response = await client.get(
-        "/api/v1/portfolio/summary", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/portfolio/summary")
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -128,13 +126,11 @@ async def test_portfolio_update_with_price_changes(
     await create_dividend(us_dividend)
 
     # ホールディングの更新
-    await client.post("/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"})
-    await client.post("/api/v1/holdings/AAPL/recalculate", headers={"Authorization": f"Bearer {auth_token}"})
+    await client.post("/api/v1/holdings/8058/recalculate")
+    await client.post("/api/v1/holdings/AAPL/recalculate")
 
     # POST /api/v1/portfolio/summary を呼び出してポートフォリオ履歴を作成
-    response = await client.post(
-        "/api/v1/portfolio/summary", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/portfolio/summary")
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -157,9 +153,7 @@ async def test_portfolio_update_with_price_changes(
     assert "USD" in created_summary["holdings_by_currency"]
 
     # データベースに正しく記録されたことを確認するために、GET でも確認
-    get_response = await client.get(
-        "/api/v1/portfolio/summary", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    get_response = await client.get("/api/v1/portfolio/summary")
     get_summary = get_response.json()
 
     # POSTとGETの結果が一致することを確認
@@ -187,20 +181,14 @@ async def test_get_portfolio_history(client, auth_token, setup_portfolio_test_da
     # まず複数の履歴データを作成（3回ポートフォリオを更新）
     for _ in range(3):
         # ホールディングの更新
-        await client.post(
-            "/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-        )
-        await client.post(
-            "/api/v1/holdings/AAPL/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        await client.post("/api/v1/holdings/8058/recalculate")
+        await client.post("/api/v1/holdings/AAPL/recalculate")
 
         # ポートフォリオ履歴を作成
-        await client.post("/api/v1/portfolio/summary", headers={"Authorization": f"Bearer {auth_token}"})
+        await client.post("/api/v1/portfolio/summary")
 
     # 履歴取得APIを呼び出す
-    response = await client.get(
-        "/api/v1/portfolio/history", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/portfolio/history")
 
     # レスポンスの検証
     assert response.status_code == 200

--- a/src/api/tests/api/test_price_history.py
+++ b/src/api/tests/api/test_price_history.py
@@ -64,7 +64,6 @@ async def test_get_japanese_stock_price_history(
     response = await client.get(
         "/api/v1/stocks/8058/price-history",
         params={"interval": "daily", "limit": 80},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンス検証
@@ -136,7 +135,6 @@ async def test_get_us_stock_price_history(
     response = await client.get(
         "/api/v1/stocks/AAPL/price-history",
         params={"interval": "daily", "limit": 80},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンス検証
@@ -218,7 +216,6 @@ async def test_get_price_history_with_weekly_interval(
     response = await client.get(
         "/api/v1/stocks/8058/price-history",
         params={"interval": "weekly", "limit": 80},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンス検証
@@ -300,7 +297,6 @@ async def test_get_price_history_with_monthly_interval(
     response = await client.get(
         "/api/v1/stocks/8058/price-history",
         params={"interval": "monthly", "limit": 60},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンス検証
@@ -332,7 +328,6 @@ async def test_get_price_history_stock_not_found(
     response = await client.get(
         "/api/v1/stocks/INVALID/price-history",
         params={"interval": "daily", "limit": 80},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンス検証
@@ -436,7 +431,6 @@ async def test_get_price_history_with_limit(
     response = await client.get(
         "/api/v1/stocks/8058/price-history",
         params={"interval": "daily", "limit": 10},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     assert response.status_code == 200
@@ -467,7 +461,6 @@ async def test_get_price_history_monthly_limit_validation(
     response = await client.get(
         "/api/v1/stocks/8058/price-history",
         params={"interval": "monthly", "limit": 61},
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     assert response.status_code == 400

--- a/src/api/tests/api/test_stock_splits.py
+++ b/src/api/tests/api/test_stock_splits.py
@@ -29,9 +29,7 @@ async def test_create_stock_split_and_recalculate(
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
     assert response.status_code == 200
 
     # 2. 4:1の株式分割を登録
@@ -40,18 +38,14 @@ async def test_create_stock_split_and_recalculate(
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    split_response = await client.post(
-        "/api/v1/stock-splits/", json=split_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    split_response = await client.post("/api/v1/stock-splits/", json=split_data)
     assert split_response.status_code == 201
     split_result = split_response.json()
     assert split_result["symbol"] == "8058"
     assert float(split_result["split_ratio"]) == 4.0
 
     # 3. 取引の調整値を確認（400株@2500円）
-    transactions_response = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    transactions_response = await client.get("/api/v1/transactions/?symbol=8058")
     assert transactions_response.status_code == 200
     transactions = transactions_response.json()
     transaction = transactions[0]
@@ -86,9 +80,7 @@ async def test_holding_calculation_with_split(client: AsyncClient, db_session: A
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 2. 4:1の株式分割を登録
     split_data = {
@@ -96,20 +88,14 @@ async def test_holding_calculation_with_split(client: AsyncClient, db_session: A
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    await client.post(
-        "/api/v1/stock-splits/", json=split_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/", json=split_data)
 
     # 3. 保有株情報を取得して再計算
-    recalc_response = await client.post(
-        "/api/v1/holdings/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    recalc_response = await client.post("/api/v1/holdings/8058/recalculate")
     assert recalc_response.status_code == 200
 
     # 4. 保有株情報を確認
-    holdings_response = await client.get(
-        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/?symbol=8058")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
     holding = holdings[0]
@@ -146,9 +132,7 @@ async def test_sell_after_split_realized_pl(client: AsyncClient, db_session: Asy
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=buy_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=buy_data)
 
     # 2. 4:1の株式分割を登録
     split_data = {
@@ -156,9 +140,7 @@ async def test_sell_after_split_realized_pl(client: AsyncClient, db_session: Asy
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    await client.post(
-        "/api/v1/stock-splits/", json=split_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/", json=split_data)
 
     # 3. 分割後に200株@3000円で売却
     sell_data = {
@@ -171,9 +153,7 @@ async def test_sell_after_split_realized_pl(client: AsyncClient, db_session: Asy
         "tax": "0.0",
         "transaction_date": "2024-07-01T00:00:00",
     }
-    sell_response = await client.post(
-        "/api/v1/transactions/", json=sell_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    sell_response = await client.post("/api/v1/transactions/", json=sell_data)
     assert sell_response.status_code == 200
     sell_transaction = sell_response.json()
 
@@ -181,9 +161,7 @@ async def test_sell_after_split_realized_pl(client: AsyncClient, db_session: Asy
     assert float(sell_transaction["realized_pl"]) == 100000.0
 
     # 5. 保有株情報を確認（残り200株）
-    holdings_response = await client.get(
-        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/?symbol=8058")
     holdings = holdings_response.json()
     holding = holdings[0]
     assert float(holding["quantity"]) == 200.0  # 400 - 200
@@ -213,9 +191,7 @@ async def test_recalculate_idempotency(client: AsyncClient, db_session: AsyncSes
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 2. 株式分割を登録
     split_data = {
@@ -223,25 +199,17 @@ async def test_recalculate_idempotency(client: AsyncClient, db_session: AsyncSes
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    await client.post(
-        "/api/v1/stock-splits/", json=split_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/", json=split_data)
 
     # 3. 1回目の取引情報取得
-    response1 = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response1 = await client.get("/api/v1/transactions/?symbol=8058")
     transaction1 = response1.json()[0]
 
     # 4. 再計算を実行
-    await client.post(
-        "/api/v1/stock-splits/8058/recalculate", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/8058/recalculate")
 
     # 5. 2回目の取引情報取得
-    response2 = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response2 = await client.get("/api/v1/transactions/?symbol=8058")
     transaction2 = response2.json()[0]
 
     # 6. 1回目と2回目で調整値が同じであることを確認
@@ -274,9 +242,7 @@ async def test_list_stock_splits_all(client: AsyncClient, db_session: AsyncSessi
             "tax": "0.0",
             "transaction_date": "2024-01-01T00:00:00",
         }
-        await client.post(
-            "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 1. 複数銘柄の分割情報を登録
     splits = [
@@ -285,12 +251,10 @@ async def test_list_stock_splits_all(client: AsyncClient, db_session: AsyncSessi
     ]
 
     for split in splits:
-        await client.post(
-            "/api/v1/stock-splits/", json=split, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        await client.post("/api/v1/stock-splits/", json=split)
 
     # 2. 全銘柄の分割履歴を取得
-    response = await client.get("/api/v1/stock-splits/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/stock-splits/")
     assert response.status_code == 200
     result = response.json()
 
@@ -325,9 +289,7 @@ async def test_list_stock_splits_by_symbol(client: AsyncClient, db_session: Asyn
             "tax": "0.0",
             "transaction_date": "2024-01-01T00:00:00",
         }
-        await client.post(
-            "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 1. 複数銘柄の分割情報を登録
     splits = [
@@ -336,14 +298,10 @@ async def test_list_stock_splits_by_symbol(client: AsyncClient, db_session: Asyn
     ]
 
     for split in splits:
-        await client.post(
-            "/api/v1/stock-splits/", json=split, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        await client.post("/api/v1/stock-splits/", json=split)
 
     # 2. 8058の分割履歴のみを取得
-    response = await client.get(
-        "/api/v1/stock-splits/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/stock-splits/?symbol=8058")
     assert response.status_code == 200
     result = response.json()
 
@@ -377,9 +335,7 @@ async def test_delete_stock_split(client: AsyncClient, db_session: AsyncSession,
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 2. 株式分割を登録
     split_data = {
@@ -387,29 +343,21 @@ async def test_delete_stock_split(client: AsyncClient, db_session: AsyncSession,
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    split_response = await client.post(
-        "/api/v1/stock-splits/", json=split_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    split_response = await client.post("/api/v1/stock-splits/", json=split_data)
     split_id = split_response.json()["split_id"]
 
     # 3. 調整値が設定されていることを確認
-    response_before = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response_before = await client.get("/api/v1/transactions/?symbol=8058")
     transaction_before = response_before.json()[0]
     assert transaction_before["adjusted_quantity"] is not None
     assert transaction_before["adjusted_price"] is not None
 
     # 4. 分割情報を削除
-    delete_response = await client.delete(
-        f"/api/v1/stock-splits/{split_id}", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    delete_response = await client.delete(f"/api/v1/stock-splits/{split_id}")
     assert delete_response.status_code == 204
 
     # 5. 調整値がNULLに戻っていることを確認
-    response_after = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response_after = await client.get("/api/v1/transactions/?symbol=8058")
     transaction_after = response_after.json()[0]
     assert transaction_after["adjusted_quantity"] is None
     assert transaction_after["adjusted_price"] is None
@@ -439,9 +387,7 @@ async def test_multiple_splits(client: AsyncClient, db_session: AsyncSession, au
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 2. 1回目の分割（4:1）
     split1_data = {
@@ -449,9 +395,7 @@ async def test_multiple_splits(client: AsyncClient, db_session: AsyncSession, au
         "split_date": "2024-06-01T00:00:00",
         "split_ratio": "4.0",
     }
-    await client.post(
-        "/api/v1/stock-splits/", json=split1_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/", json=split1_data)
 
     # 3. 2回目の分割（2:1）
     split2_data = {
@@ -459,14 +403,10 @@ async def test_multiple_splits(client: AsyncClient, db_session: AsyncSession, au
         "split_date": "2024-12-01T00:00:00",
         "split_ratio": "2.0",
     }
-    await client.post(
-        "/api/v1/stock-splits/", json=split2_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stock-splits/", json=split2_data)
 
     # 4. 調整値を確認（800株@1250円）
-    response = await client.get(
-        "/api/v1/transactions/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.get("/api/v1/transactions/?symbol=8058")
     transaction = response.json()[0]
 
     # 調整値は4 * 2 = 8倍

--- a/src/api/tests/api/test_stocks.py
+++ b/src/api/tests/api/test_stocks.py
@@ -22,9 +22,7 @@ async def test_create_japanese_stock(client: AsyncClient, db_session: AsyncSessi
     stock_data = StockCreate(symbol="8058")  # 三菱商事のシンボル
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
 
     # レスポンス検証
     assert response.status_code == 200
@@ -56,9 +54,7 @@ async def test_create_us_stock(
     stock_data = StockCreate(symbol="AAPL")  # Appleのシンボル
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
 
     # レスポンス検証
     assert response.status_code == 200
@@ -97,9 +93,7 @@ async def test_create_us_etf(
     stock_data = StockCreate(symbol="SPYD")
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
 
     # レスポンス検証
     assert response.status_code == 200
@@ -131,9 +125,7 @@ async def test_create_investment_trust(client: AsyncClient, db_session: AsyncSes
     stock_data = StockCreate(symbol="JP90C000J569")  # 投資信託のシンボル
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
 
     # レスポンス検証
     assert response.status_code == 200
@@ -164,9 +156,7 @@ async def test_create_duplicate_stock(
     stock_data = StockCreate(symbol="AAPL")  # Appleのシンボル
 
     # 最初の登録
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
     assert response.status_code == 200
     first_data = response.json()
 
@@ -179,9 +169,7 @@ async def test_create_duplicate_stock(
     mock_external_apis["search"].reset_mock()
 
     # 2回目の登録（重複）
-    response = await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/stocks/", json=stock_data.model_dump())
     assert response.status_code == 200
     second_data = response.json()
 
@@ -214,7 +202,7 @@ async def test_get_stocks(client: AsyncClient, setup_portfolio_test_data: dict, 
     # setup_portfolio_test_dataにより既に日本株と米国株が登録されている
 
     # 銘柄一覧を取得
-    response = await client.get("/api/v1/stocks/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/stocks/")
 
     # レスポンス検証
     assert response.status_code == 200
@@ -253,9 +241,7 @@ async def test_refresh_us_stock(
     """
     # まず銘柄を登録
     stock_data = StockCreate(symbol="AAPL")
-    await client.post(
-        "/api/v1/stocks/", json=stock_data.model_dump(), headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/stocks/", json=stock_data.model_dump())
 
     # モックの名前を変更して更新を検証
     mock_external_apis["overview"].return_value = {
@@ -265,7 +251,7 @@ async def test_refresh_us_stock(
     }
 
     # PUT で更新
-    response = await client.put("/api/v1/stocks/AAPL", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.put("/api/v1/stocks/AAPL")
 
     assert response.status_code == 200
     data = response.json()
@@ -276,5 +262,5 @@ async def test_refresh_us_stock(
 @pytest.mark.asyncio
 async def test_refresh_stock_not_found(client: AsyncClient, db_session: AsyncSession, auth_token: str):
     """未登録銘柄の更新で404が返ること"""
-    response = await client.put("/api/v1/stocks/ZZZZ", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.put("/api/v1/stocks/ZZZZ")
     assert response.status_code == 404

--- a/src/api/tests/api/test_transactions.py
+++ b/src/api/tests/api/test_transactions.py
@@ -30,9 +30,7 @@ async def test_create_buy_transaction(client: AsyncClient, db_session: AsyncSess
     }
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     # レスポンス検証
     assert response.status_code == 200
@@ -43,9 +41,7 @@ async def test_create_buy_transaction(client: AsyncClient, db_session: AsyncSess
     assert float(data["price"]) == 3000.0
 
     # ホールディングテーブルの状態を確認（指定銘柄のみ）
-    holdings_response = await client.get(
-        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/?symbol=8058")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
     holding = holdings[0]
@@ -79,9 +75,7 @@ async def test_create_sell_transaction(client: AsyncClient, db_session: AsyncSes
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=buy_transaction, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=buy_transaction)
 
     # 売却取引のテストデータ準備
     transaction_data = {
@@ -96,9 +90,7 @@ async def test_create_sell_transaction(client: AsyncClient, db_session: AsyncSes
     }
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     # レスポンス検証
     assert response.status_code == 200
@@ -109,9 +101,7 @@ async def test_create_sell_transaction(client: AsyncClient, db_session: AsyncSes
     assert float(data["price"]) == 3500.0
 
     # 売却後のホールディングの実現損益を確認
-    holdings_response = await client.get(
-        "/api/v1/holdings/?symbol=8058", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/?symbol=8058")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
     holding = holdings[0]
@@ -146,9 +136,7 @@ async def test_create_transaction_insufficient_shares(
     }
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     # レスポンス検証
     assert response.status_code == 400
@@ -183,9 +171,7 @@ async def test_create_transaction_stock_not_found(
     }
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     # レスポンス検証
     assert response.status_code == 404
@@ -220,9 +206,7 @@ async def test_multiple_buy_transactions_average_cost(
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=first_buy, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=first_buy)
 
     # 2回目の購入取引データ準備（5株@4000円）
     second_buy = {
@@ -235,14 +219,10 @@ async def test_multiple_buy_transactions_average_cost(
         "tax": "0.0",
         "transaction_date": "2024-01-02T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=second_buy, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=second_buy)
 
     # ポートフォリオから保有情報を取得して確認
-    holdings_response = await client.get(
-        "/api/v1/holdings/", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
 
@@ -284,9 +264,7 @@ async def test_buy_and_partial_sell_calculation(
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=buy_transaction, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=buy_transaction)
 
     # 一部売却取引データ準備（60株@1500円）
     sell_transaction = {
@@ -299,14 +277,10 @@ async def test_buy_and_partial_sell_calculation(
         "tax": "0.0",
         "transaction_date": "2024-01-02T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=sell_transaction, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=sell_transaction)
 
     # ポートフォリオから保有情報を取得して確認
-    holdings_response = await client.get(
-        "/api/v1/holdings/", headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    holdings_response = await client.get("/api/v1/holdings/")
     assert holdings_response.status_code == 200
     holdings = holdings_response.json()
 
@@ -358,9 +332,7 @@ async def test_create_transaction_with_usd_price(
     }
 
     # APIリクエスト実行
-    response = await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/transactions/", json=transaction_data)
 
     # レスポンス検証
     assert response.status_code == 200
@@ -397,12 +369,10 @@ async def test_list_transactions(client: AsyncClient, db_session: AsyncSession, 
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # 取引履歴を取得
-    response = await client.get("/api/v1/transactions/", headers={"Authorization": f"Bearer {auth_token}"})
+    response = await client.get("/api/v1/transactions/")
 
     # レスポンスの検証
     assert response.status_code == 200
@@ -437,9 +407,7 @@ async def test_list_transactions_with_unrealized_pl(
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=buy_transaction, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=buy_transaction)
 
     # 売却取引を登録
     sell_transaction = {
@@ -452,14 +420,11 @@ async def test_list_transactions_with_unrealized_pl(
         "tax": "0.0",
         "transaction_date": "2024-01-02T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=sell_transaction, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=sell_transaction)
 
     # 未実現損益を含めて取引履歴を取得
     response = await client.get(
         "/api/v1/transactions/?symbol=8058&include_unrealized_pl=true",
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンスの検証
@@ -507,14 +472,11 @@ async def test_list_transactions_without_unrealized_pl(
         "tax": "0.0",
         "transaction_date": "2024-01-01T00:00:00",
     }
-    await client.post(
-        "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    await client.post("/api/v1/transactions/", json=transaction_data)
 
     # include_unrealized_plを指定せずに取引履歴を取得
     response = await client.get(
         "/api/v1/transactions/?symbol=8058",
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンスの検証

--- a/src/api/tests/api/test_weekly_performance.py
+++ b/src/api/tests/api/test_weekly_performance.py
@@ -139,7 +139,6 @@ async def test_excludes_zero_quantity_holdings(
 
     response = await client.post(
         "/api/v1/portfolio/weekly-performance-notify",
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert response.status_code == 200
     data = response.json()
@@ -242,7 +241,6 @@ async def test_weekly_performance_notify_endpoint(
     # APIリクエスト実行
     response = await client.post(
         "/api/v1/portfolio/weekly-performance-notify",
-        headers={"Authorization": f"Bearer {auth_token}"},
     )
 
     # レスポンスの検証

--- a/src/api/tests/auth/test_auth.py
+++ b/src/api/tests/auth/test_auth.py
@@ -24,9 +24,7 @@ async def test_create_user(client: AsyncClient, auth_admin_token: str, db_sessio
     user_data = {"username": "testuser2", "email": "test2@example.com", "password": "testpassword"}
 
     # APIリクエスト実行（Authorizationヘッダーを追加）
-    response = await client.post(
-        "/api/v1/users/", json=user_data, headers={"Authorization": f"Bearer {auth_admin_token}"}
-    )
+    response = await client.post("/api/v1/users/", json=user_data)
 
     # レスポンス検証
     assert response.status_code == 200
@@ -54,14 +52,10 @@ async def test_create_duplicate_user(client: AsyncClient, auth_admin_token: str,
     user_data = {"username": "testuser3", "email": "test3@example.com", "password": "testpassword"}
 
     # 1人目のユーザーを作成
-    await client.post(
-        "/api/v1/users/", json=user_data, headers={"Authorization": f"Bearer {auth_admin_token}"}
-    )
+    await client.post("/api/v1/users/", json=user_data)
 
     # 同じユーザー名で2人目を作成
-    response = await client.post(
-        "/api/v1/users/", json=user_data, headers={"Authorization": f"Bearer {auth_admin_token}"}
-    )
+    response = await client.post("/api/v1/users/", json=user_data)
 
     # レスポンス検証
     assert response.status_code == 400
@@ -87,9 +81,7 @@ async def test_create_user_without_admin_privileges(
     user_data = {"username": "newuser", "email": "newuser@example.com", "password": "newpassword"}
 
     # 管理者権限なしでリクエスト実行
-    response = await client.post(
-        "/api/v1/users/", json=user_data, headers={"Authorization": f"Bearer {auth_token}"}
-    )
+    response = await client.post("/api/v1/users/", json=user_data)
 
     # レスポンス検証
     assert response.status_code == 403

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -146,68 +146,47 @@ async def db_session(setup_database) -> AsyncGenerator[AsyncSession, None]:
             # トランザクションは自動的にロールバックされます
 
 
-@pytest_asyncio.fixture
-async def auth_token(client: AsyncClient, setup_database) -> None:
-    """テスト用一般ユーザーを作成し、clientにCookieをセットするフィクスチャー
+async def _create_user_and_login(
+    client: AsyncClient, setup_database, username: str, email: str, password: str, is_admin: bool
+) -> None:
+    """テストユーザーをDBに作成しログインする共通ヘルパー
 
     /api/v1/token のレスポンスのSet-Cookieをhttpx AsyncClientが自動保存するため、
-    以降のリクエストはCookie認証で通る。
-
-    Args:
-        client: 非同期HTTPクライアント
-        setup_database: データベースセットアップのフィクスチャー
+    呼び出し後の同clientへのリクエストはCookie認証で通る。
     """
-    from sqlalchemy.orm import sessionmaker
-
-    # setup_databaseから新しいセッションファクトリを作成
     TestingSessionLocalFunc = sessionmaker(setup_database, class_=AsyncSession, expire_on_commit=False)
-
-    # テストユーザーのデータ
-    user_data = {
-        "username": "testuser",
-        "email": "test@example.com",
-        "password": "testpassword",
-        "is_admin": False,
-    }
-
-    # db_sessionフィクスチャと独立したセッションでユーザー作成とコミットを実施
     async with TestingSessionLocalFunc() as session:
-        await AuthService(session).create_user(UserCreate(**user_data))
+        await AuthService(session).create_user(
+            UserCreate(username=username, email=email, password=password), is_admin=is_admin
+        )
         await session.commit()
+    await client.post("/api/v1/token", json={"username": username, "password": password})
 
-    # ログイン（Set-Cookieがclientに自動保存される）
-    login_data = {"username": user_data["username"], "password": user_data["password"]}
-    await client.post("/api/v1/token", json=login_data)
+
+@pytest_asyncio.fixture
+async def auth_token(client: AsyncClient, setup_database) -> None:
+    """テスト用一般ユーザーを作成し、clientにCookieをセットするフィクスチャー"""
+    await _create_user_and_login(
+        client,
+        setup_database,
+        username="testuser",
+        email="test@example.com",
+        password="testpassword",
+        is_admin=False,
+    )
 
 
 @pytest_asyncio.fixture
 async def auth_admin_token(client: AsyncClient, setup_database) -> None:
-    """テスト用管理者ユーザーを作成し、clientにCookieをセットするフィクスチャー
-
-    /api/v1/token のレスポンスのSet-Cookieをhttpx AsyncClientが自動保存するため、
-    以降のリクエストはCookie認証で通る。
-
-    Args:
-        client: 非同期HTTPクライアント
-        setup_database: データベースセットアップのフィクスチャー
-    """
-    from sqlalchemy.orm import sessionmaker
-
-    # setup_databaseから新しいセッションファクトリを作成
-    TestingSessionLocalFunc = sessionmaker(setup_database, class_=AsyncSession, expire_on_commit=False)
-
-    # 管理者ユーザーのデータ
-    admin_user_data = {"username": "adminuser", "email": "admin@example.com", "password": "adminpassword"}
-
-    # db_sessionフィクスチャと独立したセッションでユーザー作成とコミットを実施
-    async with TestingSessionLocalFunc() as session:
-        # is_admin=Trueを明示的に渡す
-        await AuthService(session).create_user(UserCreate(**admin_user_data), is_admin=True)
-        await session.commit()
-
-    # ログイン（Set-Cookieがclientに自動保存される）
-    login_data = {"username": admin_user_data["username"], "password": admin_user_data["password"]}
-    await client.post("/api/v1/token", json=login_data)
+    """テスト用管理者ユーザーを作成し、clientにCookieをセットするフィクスチャー"""
+    await _create_user_and_login(
+        client,
+        setup_database,
+        username="adminuser",
+        email="admin@example.com",
+        password="adminpassword",
+        is_admin=True,
+    )
 
 
 @pytest_asyncio.fixture

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -147,17 +147,15 @@ async def db_session(setup_database) -> AsyncGenerator[AsyncSession, None]:
 
 
 @pytest_asyncio.fixture
-async def auth_token(client: AsyncClient, setup_database) -> str:
-    """テスト用の認証トークンを取得するフィクスチャー
+async def auth_token(client: AsyncClient, setup_database) -> None:
+    """テスト用一般ユーザーを作成し、clientにCookieをセットするフィクスチャー
 
-    認証ユーザーを新規作成し、コミットすることで別セッションでも参照可能にします。
+    /api/v1/token のレスポンスのSet-Cookieをhttpx AsyncClientが自動保存するため、
+    以降のリクエストはCookie認証で通る。
 
     Args:
         client: 非同期HTTPクライアント
         setup_database: データベースセットアップのフィクスチャー
-
-    Returns:
-        str: JWTアクセストークン
     """
     from sqlalchemy.orm import sessionmaker
 
@@ -177,24 +175,21 @@ async def auth_token(client: AsyncClient, setup_database) -> str:
         await AuthService(session).create_user(UserCreate(**user_data))
         await session.commit()
 
-    # ログインして認証トークンを取得（JSON形式でリクエスト）
+    # ログイン（Set-Cookieがclientに自動保存される）
     login_data = {"username": user_data["username"], "password": user_data["password"]}
-    response = await client.post("/api/v1/token", json=login_data)
-    return response.json()["access_token"]
+    await client.post("/api/v1/token", json=login_data)
 
 
 @pytest_asyncio.fixture
-async def auth_admin_token(client: AsyncClient, setup_database) -> str:
-    """テスト用の管理者権限トークンを取得するフィクスチャー
+async def auth_admin_token(client: AsyncClient, setup_database) -> None:
+    """テスト用管理者ユーザーを作成し、clientにCookieをセットするフィクスチャー
 
-    管理者権限を持つユーザーを新規作成し、コミットすることで別セッションでも参照可能にします。
+    /api/v1/token のレスポンスのSet-Cookieをhttpx AsyncClientが自動保存するため、
+    以降のリクエストはCookie認証で通る。
 
     Args:
         client: 非同期HTTPクライアント
         setup_database: データベースセットアップのフィクスチャー
-
-    Returns:
-        str: 管理者権限のJWTアクセストークン
     """
     from sqlalchemy.orm import sessionmaker
 
@@ -210,10 +205,9 @@ async def auth_admin_token(client: AsyncClient, setup_database) -> str:
         await AuthService(session).create_user(UserCreate(**admin_user_data), is_admin=True)
         await session.commit()
 
-    # ログインして認証トークンを取得（JSON形式でリクエスト）
+    # ログイン（Set-Cookieがclientに自動保存される）
     login_data = {"username": admin_user_data["username"], "password": admin_user_data["password"]}
-    response = await client.post("/api/v1/token", json=login_data)
-    return response.json()["access_token"]
+    await client.post("/api/v1/token", json=login_data)
 
 
 @pytest_asyncio.fixture
@@ -437,16 +431,14 @@ async def create_transaction(client, auth_token):
 
     Args:
         client: 非同期HTTPクライアント
-        auth_token: 認証トークン
+        auth_token: 認証フィクスチャ（clientにCookieをセットする副作用）
 
     Returns:
         function: 取引登録用の関数
     """
 
     async def _create_transaction(transaction_data):
-        response = await client.post(
-            "/api/v1/transactions/", json=transaction_data, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        response = await client.post("/api/v1/transactions/", json=transaction_data)
         assert response.status_code == 200
         return response.json()
 
@@ -459,16 +451,14 @@ async def create_dividend(client, auth_token):
 
     Args:
         client: 非同期HTTPクライアント
-        auth_token: 認証トークン
+        auth_token: 認証フィクスチャ（clientにCookieをセットする副作用）
 
     Returns:
         function: 配当登録用の関数
     """
 
     async def _create_dividend(dividend_data):
-        response = await client.post(
-            "/api/v1/dividends/", json=dividend_data, headers={"Authorization": f"Bearer {auth_token}"}
-        )
+        response = await client.post("/api/v1/dividends/", json=dividend_data)
         assert response.status_code == 200
         return response.json()
 


### PR DESCRIPTION
定期ジョブをCloud Run Jobsに移行済みでHTTP経由のBearer認証ユース
ケースが消滅したため、認証経路をCookieのみに整理する。

- get_current_userをCookieのみ受け付ける関数に簡素化
- /api/v1/oauth/token エンドポイントとOAuth2PasswordBearer/Form依存を削除
- 未使用のTokenData/oauth2_scheme/Headerインポートを撤去
- テストフィクスチャを「ログインによりclient.cookiesへCookieを注入する副作用」型に変更し、各テストからAuthorization Bearerヘッダ指定を撤去
- ドキュメント(AGENTS.md, testing-guide.md)の認証認可記述を更新

Swagger UIのAuthorizeボタンは廃止し、/api/v1/tokenをTry it outで実行→
Cookie自動付与で動作確認する運用に切り替える。