### PR TITLE
chore(ci): サードパーティ Actions を完全長コミット SHA でピン留め

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: google-github-actions/auth@v3
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.DEPLOYER_SA }}
 
-      - uses: google-github-actions/setup-gcloud@v3
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Build & push image
         working-directory: src/api

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install uv and Python
         id: setup-uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
           python-version: "3.13"

--- a/.github/workflows/biome-autofix.yml
+++ b/.github/workflows/biome-autofix.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.1
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10
 
@@ -42,6 +42,6 @@ jobs:
         run: pnpm run format
 
       - name: Commit fixed files
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "style: apply biome auto-fix"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: 変更検知
         id: changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             github:

--- a/.github/workflows/ruff-autofix.yml
+++ b/.github/workflows/ruff-autofix.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.13"
 
@@ -41,7 +41,7 @@ jobs:
           cd src/api && uv run ruff format --line-length=110 .
 
       - name: Commit fixed files
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "style: apply ruff auto-fix"
           skip_ci: true

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.1
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

- CodeQL の `actions/unpinned-tag` アラート（3rd party Action のタグ参照）を解消するため、6 つのサードパーティ Action を完全長コミット SHA でピン留め
- Dependabot (`github-actions` ecosystem) は既に設定済みで、SHA 形式でも自動更新 PR を上げてくれるため運用負荷の追加なし
- GitHub 公式 (`actions/*`, `github/codeql-action/*`) は CodeQL のスキップ対象なので変更なし

## 変更した Action

| Action | 旧 | 新 |
|---|---|---|
| `pnpm/action-setup` | `@v6.0.1` | `@8912a91…` (`v6.0.5`) |
| `astral-sh/setup-uv` | `@v7` | `@08807647…` (`v8.1.0`) |
| `stefanzweifel/git-auto-commit-action` | `@v7` | `@04702edd…` (`v7.1.0`) |
| `dorny/paths-filter` | `@v4` | `@fbd0ab8f…` (`v4.0.1`) |
| `google-github-actions/auth` | `@v3` | `@7c6bc770…` (`v3.0.0`) |
| `google-github-actions/setup-gcloud` | `@v3` | `@aa5489c8…` (`v3.0.1`) |

`astral-sh/setup-uv` のみ v7 → v8 のメジャーアップ。Breaking change は `manifest-file` の形式変更と major/minor タグの廃止だが、当リポジトリでは `manifest-file` 未使用、SHA ピン留めへの移行は v8 のリリースノートでも推奨されているため影響なし。

## Test plan

- [ ] CodeQL ワークフローが PR 上で走り、`actions/unpinned-tag` のアラートが 0 件になること
- [ ] `web-ci` / `api-test` が green であること
- [ ] `Biome Auto Fix` / `Ruff Auto Fix` の workflow_dispatch は実行確認は行わない（手動トリガー、書き換え範囲は uses のみで設定値はそのまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)