### PR TITLE
feat: 主要株価指数のダッシュボードカードを追加

### DIFF
--- a/src/api/stock/app.py
+++ b/src/api/stock/app.py
@@ -57,7 +57,7 @@ app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
 # 各機能のエンドポイント
 app.include_router(holdings.router, prefix="/api/v1/holdings", tags=["holdings"])
 app.include_router(stocks.router, prefix="/api/v1/stocks", tags=["stocks"])
-app.include_router(price_history.router, prefix="/api/v1/stocks", tags=["stocks"])
+app.include_router(price_history.router, prefix="/api/v1/symbols", tags=["symbols"])
 app.include_router(stock_splits.router, prefix="/api/v1/stock-splits", tags=["stock-splits"])
 app.include_router(transactions.router, prefix="/api/v1/transactions", tags=["transactions"])
 app.include_router(portfolio.router, prefix="/api/v1/portfolio", tags=["portfolio"])

--- a/src/api/stock/services/price_history_service.py
+++ b/src/api/stock/services/price_history_service.py
@@ -8,6 +8,7 @@ from typing import List
 
 import pandas as pd
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Stock
@@ -233,6 +234,22 @@ class PriceHistoryService:
             )
             raise Exception(f"Failed to fetch index prices: {str(e)}")
 
+    async def _fetch_stock_prices(self, symbol: str, start_date: str, end_date: str) -> List[dict]:
+        result = await self.db.execute(select(Stock).where(Stock.symbol == symbol))
+        stock = result.scalar_one_or_none()
+
+        if not stock:
+            logger.error("Stockが見つかりませんでした action=select symbol={} found=false", symbol)
+            raise ValueError(f"Stock {symbol} not found")
+
+        if stock.security_type == "FUND":
+            logger.error("投資信託は価格履歴未対応です action=select symbol={} security_type=FUND", symbol)
+            raise ValueError("Price history is not available for investment funds")
+
+        if stock.market in ["JPX", "東証", "東証グロース", "東証スタンダード"]:
+            return await self._fetch_japanese_stock_prices(symbol, start_date, end_date)
+        return await self._fetch_us_stock_prices(symbol, start_date, end_date)
+
     async def get_price_history(
         self,
         symbol: str,
@@ -258,38 +275,15 @@ class PriceHistoryService:
         end_date = datetime.now().strftime("%Y-%m-%d")
 
         if symbol in INDEX_SYMBOL_MAP:
-            # 主要株価指数：DB照会をスキップしStooqから直接取得
             data = self._fetch_index_prices_cached(INDEX_SYMBOL_MAP[symbol], start_date, end_date)
         else:
-            from sqlalchemy import select
+            data = await self._fetch_stock_prices(symbol, start_date, end_date)
 
-            result = await self.db.execute(select(Stock).where(Stock.symbol == symbol))
-            stock = result.scalar_one_or_none()
-
-            if not stock:
-                logger.error("Stockが見つかりませんでした action=select symbol={} found=false", symbol)
-                raise ValueError(f"Stock {symbol} not found")
-
-            # 投資信託は非対応
-            if stock.security_type == "FUND":
-                logger.error(
-                    "投資信託は価格履歴未対応です action=select symbol={} security_type=FUND", symbol
-                )
-                raise ValueError("Price history is not available for investment funds")
-
-            # 市場に応じてデータを取得
-            if stock.market in ["JPX", "東証", "東証グロース", "東証スタンダード"]:
-                data = await self._fetch_japanese_stock_prices(symbol, start_date, end_date)
-            else:  # 米国株
-                data = await self._fetch_us_stock_prices(symbol, start_date, end_date)
-
-        # 間隔に応じて集計
         if interval == PriceHistoryInterval.WEEKLY:
             data = self._aggregate_to_weekly(data)
         elif interval == PriceHistoryInterval.MONTHLY:
             data = self._aggregate_to_monthly(data)
 
-        # 最新のlimit件のみを返す
         data = data[-limit:] if len(data) > limit else data
 
         logger.info(

--- a/src/api/stock/services/price_history_service.py
+++ b/src/api/stock/services/price_history_service.py
@@ -14,7 +14,14 @@ from ..models import Stock
 from ..schemas import PriceDataPoint, PriceHistoryInterval
 from ..utils.cache import timed_cache
 from .jquants_service import get_jquants_client
-from .stooq_service import fetch_us_daily_prices_from_stooq
+from .stooq_service import fetch_daily_prices_from_stooq, fetch_us_daily_prices_from_stooq
+
+INDEX_SYMBOL_MAP: dict[str, str] = {
+    "N225": "^nkx",
+    "TOPIX": "^tpx",
+    "SP500": "^spx",
+    "NASDAQ": "^ndq",
+}
 
 
 class PriceHistoryService:
@@ -200,6 +207,32 @@ class PriceHistoryService:
         """
         return self._fetch_us_stock_prices_cached(symbol, start_date, end_date)
 
+    @staticmethod
+    @timed_cache(seconds=3600)
+    def _fetch_index_prices_cached(stooq_symbol: str, start_date: str, end_date: str) -> List[dict]:
+        """Stooqから指数の日足データを取得（1時間キャッシュ）"""
+        try:
+            result = fetch_daily_prices_from_stooq(
+                stooq_symbol, start_date, end_date, allow_missing_volume=True
+            )
+            logger.info(
+                "指数を取得しました action=external_io symbol={} start_date={} end_date={} count={}",
+                stooq_symbol,
+                start_date,
+                end_date,
+                len(result),
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                "指数の取得に失敗しました action=external_io symbol={} start_date={} end_date={} error={}",
+                stooq_symbol,
+                start_date,
+                end_date,
+                str(e),
+            )
+            raise Exception(f"Failed to fetch index prices: {str(e)}")
+
     async def get_price_history(
         self,
         symbol: str,
@@ -221,30 +254,34 @@ class PriceHistoryService:
             ValueError: 投資信託など非対応の証券種別の場合
             Exception: データ取得失敗時
         """
-        # 銘柄情報を取得して市場を判定
-        from sqlalchemy import select
-
-        result = await self.db.execute(select(Stock).where(Stock.symbol == symbol))
-        stock = result.scalar_one_or_none()
-
-        if not stock:
-            logger.error("Stockが見つかりませんでした action=select symbol={} found=false", symbol)
-            raise ValueError(f"Stock {symbol} not found")
-
-        # 投資信託は非対応
-        if stock.security_type == "FUND":
-            logger.error("投資信託は価格履歴未対応です action=select symbol={} security_type=FUND", symbol)
-            raise ValueError("Price history is not available for investment funds")
-
-        # 開始日・終了日を計算
         start_date = self._calculate_start_date(interval, limit)
         end_date = datetime.now().strftime("%Y-%m-%d")
 
-        # 市場に応じてデータを取得
-        if stock.market in ["JPX", "東証", "東証グロース", "東証スタンダード"]:
-            data = await self._fetch_japanese_stock_prices(symbol, start_date, end_date)
-        else:  # 米国株
-            data = await self._fetch_us_stock_prices(symbol, start_date, end_date)
+        if symbol in INDEX_SYMBOL_MAP:
+            # 主要株価指数：DB照会をスキップしStooqから直接取得
+            data = self._fetch_index_prices_cached(INDEX_SYMBOL_MAP[symbol], start_date, end_date)
+        else:
+            from sqlalchemy import select
+
+            result = await self.db.execute(select(Stock).where(Stock.symbol == symbol))
+            stock = result.scalar_one_or_none()
+
+            if not stock:
+                logger.error("Stockが見つかりませんでした action=select symbol={} found=false", symbol)
+                raise ValueError(f"Stock {symbol} not found")
+
+            # 投資信託は非対応
+            if stock.security_type == "FUND":
+                logger.error(
+                    "投資信託は価格履歴未対応です action=select symbol={} security_type=FUND", symbol
+                )
+                raise ValueError("Price history is not available for investment funds")
+
+            # 市場に応じてデータを取得
+            if stock.market in ["JPX", "東証", "東証グロース", "東証スタンダード"]:
+                data = await self._fetch_japanese_stock_prices(symbol, start_date, end_date)
+            else:  # 米国株
+                data = await self._fetch_us_stock_prices(symbol, start_date, end_date)
 
         # 間隔に応じて集計
         if interval == PriceHistoryInterval.WEEKLY:

--- a/src/api/stock/services/stooq_service.py
+++ b/src/api/stock/services/stooq_service.py
@@ -26,18 +26,21 @@ def _build_stooq_symbol(symbol: str) -> str:
     return f"{normalized}.us"
 
 
-def fetch_us_daily_prices_from_stooq(
-    symbol: str,
+def fetch_daily_prices_from_stooq(
+    stooq_symbol: str,
     start_date: DateInput,
     end_date: DateInput,
+    *,
+    allow_missing_volume: bool = False,
 ) -> list[dict]:
     """
-    Stooq から米国株の日足データを取得する。
+    Stooq から日足データを取得する汎用関数。
+    stooq_symbol はサフィックス処理済みの生シンボル（例: "aapl.us" / "^spx"）。
+    指数のようにVolumeが "N/D" になり得るケースは allow_missing_volume=True で 0 扱いする。
     返却データは日付の昇順（古い順）。
     """
     start = _to_date(start_date)
     end = _to_date(end_date)
-    stooq_symbol = _build_stooq_symbol(symbol)
     url = f"https://stooq.com/q/d/l/?s={stooq_symbol}&i=d"
 
     try:
@@ -46,7 +49,7 @@ def fetch_us_daily_prices_from_stooq(
     except Exception as e:
         logger.error(
             "Stooqへのリクエストに失敗しました action=external_io symbol={} error={}",
-            symbol,
+            stooq_symbol,
             str(e),
         )
         raise
@@ -62,9 +65,16 @@ def fetch_us_daily_prices_from_stooq(
             or row.get("High") in (None, "N/D")
             or row.get("Low") in (None, "N/D")
             or row.get("Close") in (None, "N/D")
-            or row.get("Volume") in (None, "N/D")
         ):
             continue
+
+        volume_raw = row.get("Volume")
+        if volume_raw in (None, "N/D"):
+            if not allow_missing_volume:
+                continue
+            volume = 0
+        else:
+            volume = int(float(volume_raw))
 
         record_date = datetime.strptime(row["Date"], "%Y-%m-%d").date()
         if record_date < start or record_date > end:
@@ -77,9 +87,21 @@ def fetch_us_daily_prices_from_stooq(
                 "high": float(row["High"]),
                 "low": float(row["Low"]),
                 "close": float(row["Close"]),
-                "volume": int(float(row["Volume"])),
+                "volume": volume,
             }
         )
 
     rows.sort(key=lambda x: x["date"])
     return rows
+
+
+def fetch_us_daily_prices_from_stooq(
+    symbol: str,
+    start_date: DateInput,
+    end_date: DateInput,
+) -> list[dict]:
+    """
+    Stooq から米国株の日足データを取得する。
+    返却データは日付の昇順（古い順）。
+    """
+    return fetch_daily_prices_from_stooq(_build_stooq_symbol(symbol), start_date, end_date)

--- a/src/api/tests/api/test_price_history.py
+++ b/src/api/tests/api/test_price_history.py
@@ -62,7 +62,7 @@ async def test_get_japanese_stock_price_history(
 
     # APIリクエスト実行
     response = await client.get(
-        "/api/v1/stocks/8058/price-history",
+        "/api/v1/symbols/8058/price-history",
         params={"interval": "daily", "limit": 80},
     )
 
@@ -133,7 +133,7 @@ async def test_get_us_stock_price_history(
 
     # APIリクエスト実行
     response = await client.get(
-        "/api/v1/stocks/AAPL/price-history",
+        "/api/v1/symbols/AAPL/price-history",
         params={"interval": "daily", "limit": 80},
     )
 
@@ -214,7 +214,7 @@ async def test_get_price_history_with_weekly_interval(
 
     # APIリクエスト実行（週次指定）
     response = await client.get(
-        "/api/v1/stocks/8058/price-history",
+        "/api/v1/symbols/8058/price-history",
         params={"interval": "weekly", "limit": 80},
     )
 
@@ -295,7 +295,7 @@ async def test_get_price_history_with_monthly_interval(
 
     # APIリクエスト実行（月次指定）
     response = await client.get(
-        "/api/v1/stocks/8058/price-history",
+        "/api/v1/symbols/8058/price-history",
         params={"interval": "monthly", "limit": 60},
     )
 
@@ -326,7 +326,7 @@ async def test_get_price_history_stock_not_found(
     """
     # APIリクエスト実行（存在しない銘柄）
     response = await client.get(
-        "/api/v1/stocks/INVALID/price-history",
+        "/api/v1/symbols/INVALID/price-history",
         params={"interval": "daily", "limit": 80},
     )
 
@@ -370,7 +370,7 @@ async def test_get_price_history_without_auth(
     async with AsyncClient(transport=transport, base_url="http://test") as test_client:
         # APIリクエスト実行（認証ヘッダーなし、cookieなし）
         response = await test_client.get(
-            "/api/v1/stocks/8058/price-history",
+            "/api/v1/symbols/8058/price-history",
             params={"interval": "daily", "limit": 80},
         )
 
@@ -429,13 +429,66 @@ async def test_get_price_history_with_limit(
 
     # limit=10でテスト
     response = await client.get(
-        "/api/v1/stocks/8058/price-history",
+        "/api/v1/symbols/8058/price-history",
         params={"interval": "daily", "limit": 10},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert len(data["data"]) == 10
+
+
+@pytest.mark.asyncio
+async def test_get_index_price_history(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_token: str,
+    mocker,
+):
+    """主要株価指数の取得テスト（正常系）
+
+    期待する動作:
+    - DB登録不要でステータスコード200
+    - Stooqから指数シンボル（^spx）で取得されること
+    """
+    mock_index_data = [
+        {
+            "date": "2025-01-20",
+            "open": 5800.0,
+            "high": 5850.0,
+            "low": 5780.0,
+            "close": 5820.0,
+            "volume": 0,
+        },
+        {
+            "date": "2025-01-21",
+            "open": 5820.0,
+            "high": 5880.0,
+            "low": 5810.0,
+            "close": 5860.0,
+            "volume": 0,
+        },
+    ]
+
+    mock_fetch_index = mocker.patch(
+        "stock.services.price_history_service.PriceHistoryService._fetch_index_prices_cached",
+        return_value=mock_index_data,
+    )
+
+    response = await client.get(
+        "/api/v1/symbols/SP500/price-history",
+        params={"interval": "daily", "limit": 10},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["symbol"] == "SP500"
+    assert data["interval"] == "daily"
+    assert len(data["data"]) == 2
+    assert data["data"][0]["close"] == 5820.0
+
+    mock_fetch_index.assert_called_once()
+    assert mock_fetch_index.call_args.args[0] == "^spx"
 
 
 @pytest.mark.asyncio
@@ -459,7 +512,7 @@ async def test_get_price_history_monthly_limit_validation(
     """
     # limit=61でリクエスト（月足の上限60を超える）
     response = await client.get(
-        "/api/v1/stocks/8058/price-history",
+        "/api/v1/symbols/8058/price-history",
         params={"interval": "monthly", "limit": 61},
     )
 

--- a/src/web/src/components/dashboard/dashboard.tsx
+++ b/src/web/src/components/dashboard/dashboard.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/api/client"
 import { AssetChart } from "./asset-chart"
 import { DividendChart } from "./dividend-chart"
+import { MarketIndicesCards } from "./market-indices-cards"
 import { NisaLimitGauge } from "./nisa-limit-gauge"
 import { StatCards } from "./stat-cards"
 import { TradeChart } from "./trade-chart"
@@ -57,6 +58,7 @@ export function Dashboard() {
         </Button>
       </div>
       <StatCards summary={summary} isLoading={summaryLoading} />
+      <MarketIndicesCards />
       <NisaLimitGauge data={trades} isLoading={tradesLoading} />
       <AssetChart history={history} isLoading={historyLoading} />
       <div className="grid gap-6 lg:grid-cols-2">

--- a/src/web/src/components/dashboard/market-indices-cards.test.tsx
+++ b/src/web/src/components/dashboard/market-indices-cards.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react"
+import { SWRConfig } from "swr"
+import { describe, expect, it, vi } from "vitest"
+import type { PriceHistoryResponse } from "@/lib/api/types"
+import { MarketIndicesCards } from "./market-indices-cards"
+
+vi.mock("@/lib/api/client", () => ({
+  getPriceHistory: vi.fn(),
+}))
+
+import { getPriceHistory } from "@/lib/api/client"
+
+function renderIsolated() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <MarketIndicesCards />
+    </SWRConfig>
+  )
+}
+
+function makeHistory(symbol: string, closes: number[]): PriceHistoryResponse {
+  return {
+    symbol,
+    interval: "daily",
+    data: closes.map((close, i) => ({
+      date: `2026-05-0${i + 1}`,
+      open: close,
+      high: close,
+      low: close,
+      close,
+      volume: 0,
+    })),
+  }
+}
+
+describe("MarketIndicesCards", () => {
+  it("4指数のラベル・最新値・騰落率が表示される", async () => {
+    // 6営業日分（末尾と末尾-5要素で計算）
+    const responses: Record<string, PriceHistoryResponse> = {
+      N225: makeHistory("N225", [37000, 37200, 37500, 37800, 38000, 38500]), // +4.05%
+      TOPIX: makeHistory("TOPIX", [2700, 2720, 2730, 2740, 2750, 2700]), // 0.00%
+      SP500: makeHistory("SP500", [6000, 5950, 5900, 5850, 5800, 5700]), // -5.00%
+      NASDAQ: makeHistory("NASDAQ", [20000, 20100, 20200, 20300, 20400, 20500]), // +2.50%
+    }
+    vi.mocked(getPriceHistory).mockImplementation(async (symbol: string) => responses[symbol])
+
+    renderIsolated()
+
+    expect(await screen.findByText("日経平均")).toBeInTheDocument()
+    expect(screen.getByText("TOPIX")).toBeInTheDocument()
+    expect(screen.getByText("S&P 500")).toBeInTheDocument()
+    expect(screen.getByText("NASDAQ")).toBeInTheDocument()
+
+    // JPYは整数表示
+    expect(await screen.findByText("38,500")).toBeInTheDocument()
+    // USDは小数2桁
+    expect(await screen.findByText("5,700.00")).toBeInTheDocument()
+
+    // 騰落率
+    expect(await screen.findByText("+4.1%")).toBeInTheDocument()
+    expect(await screen.findByText("-5.0%")).toBeInTheDocument()
+  })
+
+  it("プラスは緑、マイナスは赤のクラスが付く", async () => {
+    const responses: Record<string, PriceHistoryResponse> = {
+      N225: makeHistory("N225", [100, 101, 102, 103, 104, 110]),
+      TOPIX: makeHistory("TOPIX", [100, 101, 102, 103, 104, 110]),
+      SP500: makeHistory("SP500", [110, 109, 108, 107, 106, 100]),
+      NASDAQ: makeHistory("NASDAQ", [110, 109, 108, 107, 106, 100]),
+    }
+    vi.mocked(getPriceHistory).mockImplementation(async (symbol: string) => responses[symbol])
+
+    renderIsolated()
+
+    const positive = await screen.findAllByText("+10.0%")
+    expect(positive[0]).toHaveClass("text-[#4CAF50]")
+
+    const negative = await screen.findAllByText("-9.1%")
+    expect(negative[0]).toHaveClass("text-destructive")
+  })
+})

--- a/src/web/src/components/dashboard/market-indices-cards.tsx
+++ b/src/web/src/components/dashboard/market-indices-cards.tsx
@@ -22,18 +22,16 @@ function calcWeeklyChange(history: PriceHistoryResponse | undefined): {
   latest: number | null
   changePct: number | null
 } {
-  if (!history?.data || history.data.length === 0) {
+  const data = history?.data
+  if (!data || data.length === 0) {
     return { latest: null, changePct: null }
   }
-  const latest = history.data[history.data.length - 1].close
-  // 5営業日前との比較。データ不足時は最古の値で代用
-  const baseIndex = Math.max(0, history.data.length - 1 - 5)
-  const base = history.data[baseIndex].close
-  if (base === 0) {
+  const latest = data[data.length - 1].close
+  if (data.length < 6) {
     return { latest, changePct: null }
   }
-  const changePct = (latest / base - 1) * 100
-  return { latest, changePct }
+  const base = data[data.length - 6].close
+  return { latest, changePct: (latest / base - 1) * 100 }
 }
 
 function formatIndexValue(value: number | null, currency: "JPY" | "USD"): string {

--- a/src/web/src/components/dashboard/market-indices-cards.tsx
+++ b/src/web/src/components/dashboard/market-indices-cards.tsx
@@ -1,0 +1,89 @@
+import { TrendingDown, TrendingUp } from "lucide-react"
+import useSWR from "swr"
+import { Card, CardContent } from "@/components/ui/card"
+import { getPriceHistory } from "@/lib/api/client"
+import type { PriceHistoryResponse } from "@/lib/api/types"
+import { formatPercent } from "@/lib/format"
+
+type IndexDef = {
+  symbol: string
+  label: string
+  currency: "JPY" | "USD"
+}
+
+const INDICES: readonly IndexDef[] = [
+  { symbol: "N225", label: "日経平均", currency: "JPY" },
+  { symbol: "TOPIX", label: "TOPIX", currency: "JPY" },
+  { symbol: "SP500", label: "S&P 500", currency: "USD" },
+  { symbol: "NASDAQ", label: "NASDAQ", currency: "USD" },
+] as const
+
+function calcWeeklyChange(history: PriceHistoryResponse | undefined): {
+  latest: number | null
+  changePct: number | null
+} {
+  if (!history?.data || history.data.length === 0) {
+    return { latest: null, changePct: null }
+  }
+  const latest = history.data[history.data.length - 1].close
+  // 5営業日前との比較。データ不足時は最古の値で代用
+  const baseIndex = Math.max(0, history.data.length - 1 - 5)
+  const base = history.data[baseIndex].close
+  if (base === 0) {
+    return { latest, changePct: null }
+  }
+  const changePct = (latest / base - 1) * 100
+  return { latest, changePct }
+}
+
+function formatIndexValue(value: number | null, currency: "JPY" | "USD"): string {
+  if (value === null) return "-"
+  const fractionDigits = currency === "JPY" ? 0 : 2
+  return new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value)
+}
+
+function IndexCard({ index }: { index: IndexDef }) {
+  const { data, isLoading } = useSWR(`market-index-${index.symbol}`, () =>
+    getPriceHistory(index.symbol, "daily", 10)
+  )
+  const { latest, changePct } = calcWeeklyChange(data)
+  const isPositive = changePct !== null && changePct >= 0
+  const color =
+    changePct === null ? "text-muted-foreground" : isPositive ? "text-[#4CAF50]" : "text-destructive"
+  const bgColor = changePct === null ? "bg-muted/30" : isPositive ? "bg-[#4CAF50]/10" : "bg-destructive/10"
+  const Icon = isPositive ? TrendingUp : TrendingDown
+
+  return (
+    <Card className="py-4">
+      <CardContent className="flex items-center gap-4">
+        <div className={`flex h-12 w-12 items-center justify-center rounded-lg ${bgColor}`}>
+          <Icon className={`h-6 w-6 ${color}`} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm text-muted-foreground">{index.label}</p>
+          {isLoading ? (
+            <div className="h-7 w-24 animate-pulse rounded bg-muted" />
+          ) : (
+            <>
+              <p className="text-xl font-bold">{formatIndexValue(latest, index.currency)}</p>
+              <p className={`text-sm font-medium ${color}`}>{formatPercent(changePct)}</p>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function MarketIndicesCards() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {INDICES.map((index) => (
+        <IndexCard key={index.symbol} index={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/web/src/components/stock/price-chart.tsx
+++ b/src/web/src/components/stock/price-chart.tsx
@@ -88,7 +88,7 @@ export function PriceChart({ symbol, securityType, transactions }: PriceChartPro
   const limit = interval === "monthly" ? 60 : 80
 
   const { data, isLoading, error } = useSWR(
-    securityType === "FUND" ? null : `/stocks/${symbol}/price-history?interval=${interval}&limit=${limit}`,
+    securityType === "FUND" ? null : `/symbols/${symbol}/price-history?interval=${interval}&limit=${limit}`,
     () => getPriceHistory(symbol, interval, limit)
   )
 

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -142,7 +142,7 @@ export async function getPriceHistory(
     limit: limit.toString(),
   })
   return fetchWithAuth<PriceHistoryResponse>(
-    `/api/v1/stocks/${encodeURIComponent(symbol)}/price-history?${params.toString()}`
+    `/api/v1/symbols/${encodeURIComponent(symbol)}/price-history?${params.toString()}`
   )
 }
 


### PR DESCRIPTION
- price-history を /api/v1/stocks → /api/v1/symbols にプレフィックス改名し、株式と指数を「symbol」で統一的に扱う
- INDEX_SYMBOL_MAP（N225/TOPIX/SP500/NASDAQ → Stooq の ^nkx/^tpx/^spx/^ndq）を追加し、指数はDB照会をスキップして取得
- Stooq サービスに汎用関数 fetch_daily_prices_from_stooq を切り出し、Volume が N/D の指数にも対応
- フロントに MarketIndicesCards を追加し、4指数の最新値と1週間騰落率をダッシュボードに表示