### PR TITLE
fix(api): 指数シンボル(^xxx)の URL エンコーディング不備を修正

### DIFF
--- a/src/api/stock/services/stooq_service.py
+++ b/src/api/stock/services/stooq_service.py
@@ -41,10 +41,13 @@ def fetch_daily_prices_from_stooq(
     """
     start = _to_date(start_date)
     end = _to_date(end_date)
-    url = f"https://stooq.com/q/d/l/?s={stooq_symbol}&i=d"
 
     try:
-        response = httpx.get(url, timeout=10.0)
+        response = httpx.get(
+            "https://stooq.com/q/d/l/",
+            params={"s": stooq_symbol, "i": "d"},
+            timeout=10.0,
+        )
         response.raise_for_status()
     except Exception as e:
         logger.error(


### PR DESCRIPTION
httpx.get に URL 文字列を直接渡していたため `^` が生のまま送信され、Stooq 側で指数シンボルが正しく解釈されず空CSVが返っていた。params 引数経由で渡すことで `%5E` に正しくエンコードされる。米国個別株(aapl.us 等)はそもそも `^` を含まないため影響なし。

https://claude.ai/code/session_01YWe9Bpx9Nktpj77nY7GtQM