### PR TITLE
feat(api,infra): recalc_holdings ジョブで価格取得失敗を検知してアラート通知

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -28,3 +28,6 @@ TF_VAR_cors_origins='["https://example.com","http://localhost:5173"]'
 
 # CD (GitHub Actions) 用。WIF の attribute_condition で repository を絞るため必須。
 TF_VAR_github_repository="<github-owner>/<repo>"
+
+# Cloud Monitoring からのジョブ失敗通知メール送信先（管理者）。
+TF_VAR_alert_email="<your-email@example.com>"

--- a/infra/README.md
+++ b/infra/README.md
@@ -29,6 +29,7 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
 | `cloud_scheduler.tf` | Cloud Scheduler × 3（OAuth 認証で Job をキック） |
 | `artifact_registry.tf` | コンテナイメージ置き場 |
 | `workload_identity.tf` | GitHub Actions が鍵レスで成り代わるための WIF |
+| `monitoring.tf` | Cloud Run Jobs の失敗を検知する Notification Channel と Alert Policy |
 | `outputs.tf` | 最小限の output（sensitive） |
 
 ## 設計方針

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,0 +1,41 @@
+# Cloud Monitoring: recalc-holdings ジョブの失敗を検知して管理者にメール通知する。
+# ジョブは失敗銘柄が1件でもあれば exit 1 で終了するため、Cloud Run Jobs の
+# completed_execution_count{result="failed"} を監視すれば検知できる。
+
+resource "google_monitoring_notification_channel" "dev_email" {
+  display_name = "InvestLogix dev email"
+  type         = "email"
+  labels = {
+    email_address = var.alert_email
+  }
+}
+
+resource "google_monitoring_alert_policy" "recalc_holdings_failed" {
+  display_name = "recalc_holdings job failed"
+  combiner     = "OR"
+
+  notification_channels = [google_monitoring_notification_channel.dev_email.id]
+
+  conditions {
+    display_name = "recalc-holdings completed_execution_count result=failed > 0"
+    condition_threshold {
+      filter = join(" AND ", [
+        "resource.type = \"cloud_run_job\"",
+        "resource.labels.job_name = \"recalc-holdings\"",
+        "metric.type = \"run.googleapis.com/job/completed_execution_count\"",
+        "metric.labels.result = \"failed\"",
+      ])
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  alert_strategy {
+    auto_close = "604800s" # 7日
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -69,3 +69,9 @@ variable "artifact_registry_repo_id" {
   description = "Cloud Run が参照する Artifact Registry リポジトリ名。Cloud Build の自動生成リポを流用するためデフォルトは cloud-run-source-deploy。"
   default     = "cloud-run-source-deploy"
 }
+
+variable "alert_email" {
+  type        = string
+  description = "Cloud Monitoring からのジョブ失敗通知メール送信先（管理者）。"
+  sensitive   = true
+}

--- a/src/api/stock/jobs/_runner.py
+++ b/src/api/stock/jobs/_runner.py
@@ -16,7 +16,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..database import AsyncSessionLocal, set_rls_user_id
 from ..models import User
 
-# action は失敗銘柄リストを返してもよい（None の場合は集計対象外）
 UserAction = Callable[[AsyncSession, User], Awaitable[Optional[List[str]]]]
 
 # サマリログに含める失敗銘柄の最大数。これを超えた分は省略件数として記録する

--- a/src/api/stock/jobs/_runner.py
+++ b/src/api/stock/jobs/_runner.py
@@ -2,12 +2,12 @@
 ジョブ共通ランナー
 - LINE連携済みユーザーを対象に、ユーザー単位でDBセッションを発行して処理を実行する
 - 1ユーザーの失敗は記録して次のユーザーへ進む
-- 1件でも失敗した場合は終了コード1で終了しCloud Run Jobsのリトライ対象にする
+- ユーザー単位の失敗、または銘柄レベルの価格取得失敗が1件でもあれば終了コード1で終了する
 """
 
 import asyncio
 import sys
-from typing import Awaitable, Callable, List
+from typing import Awaitable, Callable, List, Optional
 
 from loguru import logger
 from sqlalchemy import select
@@ -16,7 +16,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..database import AsyncSessionLocal, set_rls_user_id
 from ..models import User
 
-UserAction = Callable[[AsyncSession, User], Awaitable[None]]
+# action は失敗銘柄リストを返してもよい（None の場合は集計対象外）
+UserAction = Callable[[AsyncSession, User], Awaitable[Optional[List[str]]]]
+
+# サマリログに含める失敗銘柄の最大数。これを超えた分は省略件数として記録する
+MAX_FAILED_SYMBOLS_IN_LOG = 50
 
 
 async def _fetch_target_users() -> List[User]:
@@ -26,35 +30,52 @@ async def _fetch_target_users() -> List[User]:
         return list(result.scalars().all())
 
 
-async def _run_for_each_user(job_name: str, action: UserAction) -> int:
-    """対象ユーザー全員に対して action を実行し、失敗件数を返す"""
+async def _run_for_each_user(job_name: str, action: UserAction) -> tuple[int, set[str]]:
+    """対象ユーザー全員に対して action を実行し、ユーザー失敗数と失敗銘柄集合を返す"""
     users = await _fetch_target_users()
     logger.info("ジョブを開始します job={} target_users={}", job_name, len(users))
 
     failure_count = 0
+    failed_symbols: set[str] = set()
     for user in users:
         async with AsyncSessionLocal() as session:
             try:
                 await set_rls_user_id(session, user.user_id)
-                await action(session, user)
+                result = await action(session, user)
                 await session.commit()
+                if result:
+                    failed_symbols.update(result)
                 logger.info("ユーザー処理が完了しました job={} user_id={}", job_name, user.user_id)
             except Exception:
                 await session.rollback()
                 failure_count += 1
                 logger.exception("ユーザー処理が失敗しました job={} user_id={}", job_name, user.user_id)
 
-    logger.info(
-        "ジョブを終了します job={} target_users={} failures={}",
+    _log_summary(job_name, len(users), failure_count, failed_symbols)
+    return failure_count, failed_symbols
+
+
+def _log_summary(job_name: str, target_users: int, failure_count: int, failed_symbols: set[str]) -> None:
+    """ジョブ末尾のサマリログを構造化して出力する"""
+    symbols_sorted = sorted(failed_symbols)
+    truncated = symbols_sorted[:MAX_FAILED_SYMBOLS_IN_LOG]
+    omitted = max(0, len(symbols_sorted) - MAX_FAILED_SYMBOLS_IN_LOG)
+    has_failure = failure_count > 0 or bool(symbols_sorted)
+    log = logger.error if has_failure else logger.info
+    log(
+        "summary action=job_complete job={} target_users={} user_failures={} "
+        "failed_symbol_count={} failed_symbols_omitted={} failed_symbols={}",
         job_name,
-        len(users),
+        target_users,
         failure_count,
+        len(symbols_sorted),
+        omitted,
+        truncated,
     )
-    return failure_count
 
 
 def run_job(job_name: str, action: UserAction) -> None:
-    """ジョブのエントリポイント。失敗があれば非ゼロで終了する"""
-    failure_count = asyncio.run(_run_for_each_user(job_name, action))
-    if failure_count > 0:
+    """ジョブのエントリポイント。ユーザー失敗または失敗銘柄があれば非ゼロで終了する"""
+    failure_count, failed_symbols = asyncio.run(_run_for_each_user(job_name, action))
+    if failure_count > 0 or failed_symbols:
         sys.exit(1)

--- a/src/api/stock/jobs/recalc_holdings.py
+++ b/src/api/stock/jobs/recalc_holdings.py
@@ -10,8 +10,9 @@ from ..services.holding_service import update_all_holdings_pl
 from ._runner import run_job
 
 
-async def _action(db: AsyncSession, user: User) -> None:
-    await update_all_holdings_pl(db, user.user_id)
+async def _action(db: AsyncSession, user: User) -> list[str]:
+    _, failed_symbols = await update_all_holdings_pl(db, user.user_id)
+    return failed_symbols
 
 
 def main() -> None:

--- a/src/api/stock/routes/holdings.py
+++ b/src/api/stock/routes/holdings.py
@@ -84,4 +84,5 @@ async def recalculate_all_holdings_pl(
     Returns:
         List[Holding]: 更新された保有情報のリスト
     """
-    return await holding_service.update_all_holdings_pl(db, current_user.user_id)
+    holdings, _ = await holding_service.update_all_holdings_pl(db, current_user.user_id)
+    return holdings

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 from loguru import logger
 from sqlalchemy import func, select
@@ -14,6 +14,11 @@ from .stock_price_fetcher import (
     get_latest_japan_price,
     get_latest_us_price,
 )
+
+
+class HoldingUpdateResult(NamedTuple):
+    updated: bool
+    price_fetch_failed: bool
 
 
 async def get_japan_stock_price(symbol: str) -> float:
@@ -223,7 +228,7 @@ async def calculate_total_dividend_after_tax(
 async def calculate_holding_pl(
     db: AsyncSession,
     holding: models.Holding,
-) -> bool:
+) -> HoldingUpdateResult:
     """
     保有銘柄の損益情報を計算して更新する
 
@@ -232,7 +237,7 @@ async def calculate_holding_pl(
         holding (models.Holding): 更新対象のホールディング
 
     Returns:
-        bool: 更新に成功した場合は True、必要情報が不足した場合は False
+        HoldingUpdateResult: updated=損益計算まで進めたか、price_fetch_failed=価格取得が失敗扱いか
     """
     # 銘柄情報を取得
     stock_query = select(models.Stock).where(models.Stock.symbol == holding.symbol)
@@ -240,7 +245,7 @@ async def calculate_holding_pl(
     stock = stock_result.scalar_one_or_none()
     if not stock:
         logger.info("Stockが見つかりませんでした action=select symbol={}", holding.symbol)
-        return False
+        return HoldingUpdateResult(updated=False, price_fetch_failed=True)
     logger.info(
         "Stockを取得しました action=select user_id={} symbol={} found=true",
         holding.user_id,
@@ -265,11 +270,19 @@ async def calculate_holding_pl(
 
     # 現在値を取得
     current_price = await get_current_price(stock)
+    price_fetch_failed = current_price <= 0
     if current_price > 0:
         holding.current_price = current_price
     elif current_price == 0 and holding.current_price is None:
         # 上場廃止などで株価が取得できない場合は0を設定
         holding.current_price = 0.0
+
+    if price_fetch_failed:
+        logger.warning(
+            "価格取得に失敗しました action=price_fetch user_id={} symbol={}",
+            holding.user_id,
+            holding.symbol,
+        )
 
     # 現在値がない場合でも、初回取得時以外は既存の価格で計算を続行
     # 上場廃止銘柄でも実現損益と配当を反映するため、損益計算は必ず実行
@@ -279,7 +292,7 @@ async def calculate_holding_pl(
             "Holdingsの更新をスキップしました action=update symbol={} reason=no_current_price",
             holding.symbol,
         )
-        return False
+        return HoldingUpdateResult(updated=False, price_fetch_failed=True)
 
     # 時価評価額の計算
     holding.market_value = holding.current_price * holding.quantity
@@ -300,7 +313,7 @@ async def calculate_holding_pl(
         (holding.total_pl / holding.total_cost * 100) if holding.total_cost > 0 else 0.0
     )
 
-    return True
+    return HoldingUpdateResult(updated=True, price_fetch_failed=price_fetch_failed)
 
 
 async def update_single_holding_pl(db: AsyncSession, user_id: int, symbol: str) -> Holding:
@@ -326,8 +339,8 @@ async def update_single_holding_pl(db: AsyncSession, user_id: int, symbol: str) 
     logger.info("Holdingsを取得しました action=select user_id={} symbol={} found=true", user_id, symbol)
 
     # 損益情報を更新
-    updated = await calculate_holding_pl(db, holding)
-    if updated:
+    result = await calculate_holding_pl(db, holding)
+    if result.updated:
         await db.flush()
         await db.refresh(holding)
         logger.info("Holdingsを更新しました action=update user_id={} symbol={}", user_id, symbol)
@@ -364,7 +377,7 @@ async def update_holding_note(
     return holding
 
 
-async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> List[Holding]:
+async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> tuple[List[Holding], List[str]]:
     """
     ユーザーの保有する全銘柄の損益を一括更新します。
 
@@ -373,17 +386,22 @@ async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> List[Holding
         user_id (int): ユーザーID
 
     Returns:
-        List[Holding]: 更新された保有情報のリスト
+        tuple[List[Holding], List[str]]:
+            - 更新された保有情報のリスト
+            - 価格取得に失敗した銘柄シンボルのリスト（ユーザ内ユニーク）
     """
     # 保有銘柄一覧を取得
     holdings = await list_holdings(db, user_id)
     updated_holdings = []
+    failed_symbols: list[str] = []
 
     # 各銘柄を更新
     for holding in holdings:
-        updated = await calculate_holding_pl(db, holding)
-        if updated:
+        result = await calculate_holding_pl(db, holding)
+        if result.updated:
             updated_holdings.append(holding)
+        if result.price_fetch_failed and holding.symbol not in failed_symbols:
+            failed_symbols.append(holding.symbol)
 
     # 一括でフラッシュ
     await db.flush()
@@ -393,13 +411,14 @@ async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> List[Holding
         await db.refresh(holding)
 
     logger.info(
-        "Holdingsを更新しました action=bulk_update user_id={} holdings={} updated={}",
+        "Holdingsを更新しました action=bulk_update user_id={} holdings={} updated={} failed={}",
         user_id,
         len(holdings),
         len(updated_holdings),
+        len(failed_symbols),
     )
 
-    return updated_holdings
+    return updated_holdings, failed_symbols
 
 
 async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> List[Holding]:

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -268,9 +268,14 @@ async def calculate_holding_pl(
     # 配当総額を配当テーブルから再集計（税・手数料控除後）
     holding.total_dividend = await calculate_total_dividend_after_tax(db, holding.user_id, holding.symbol)
 
-    # 現在値を取得
-    current_price = await get_current_price(stock)
-    price_fetch_failed = current_price <= 0
+    # 現在値を取得（保有数ゼロの銘柄は売却済み・上場廃止扱いとして価格取得自体をスキップする）
+    if holding.quantity > 0:
+        current_price = await get_current_price(stock)
+        price_fetch_failed = current_price <= 0
+    else:
+        current_price = 0.0
+        price_fetch_failed = False
+
     if current_price > 0:
         holding.current_price = current_price
     elif current_price == 0 and holding.current_price is None:

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -393,15 +393,15 @@ async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> tuple[List[H
     # 保有銘柄一覧を取得
     holdings = await list_holdings(db, user_id)
     updated_holdings = []
-    failed_symbols: list[str] = []
+    failed_symbols: set[str] = set()
 
     # 各銘柄を更新
     for holding in holdings:
         result = await calculate_holding_pl(db, holding)
         if result.updated:
             updated_holdings.append(holding)
-        if result.price_fetch_failed and holding.symbol not in failed_symbols:
-            failed_symbols.append(holding.symbol)
+        if result.price_fetch_failed:
+            failed_symbols.add(holding.symbol)
 
     # 一括でフラッシュ
     await db.flush()
@@ -411,14 +411,14 @@ async def update_all_holdings_pl(db: AsyncSession, user_id: int) -> tuple[List[H
         await db.refresh(holding)
 
     logger.info(
-        "Holdingsを更新しました action=bulk_update user_id={} holdings={} updated={} failed={}",
+        "Holdingsを更新しました action=bulk_update user_id={} holdings={} updated={} failed_symbol_count={}",
         user_id,
         len(holdings),
         len(updated_holdings),
         len(failed_symbols),
     )
 
-    return updated_holdings, failed_symbols
+    return updated_holdings, sorted(failed_symbols)
 
 
 async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> List[Holding]:

--- a/src/api/stock/services/portfolio_service.py
+++ b/src/api/stock/services/portfolio_service.py
@@ -151,7 +151,7 @@ class PortfolioService:
             Dict: 処理結果とポートフォリオサマリー
         """
         # 全銘柄の最新株価を取得して更新
-        await update_all_holdings_pl(self.db, user_id)
+        _, _ = await update_all_holdings_pl(self.db, user_id)
 
         # ポートフォリオの状態を履歴に保存
         portfolio_history = await self.create_portfolio_history(user_id)

--- a/src/api/stock/services/portfolio_service.py
+++ b/src/api/stock/services/portfolio_service.py
@@ -151,7 +151,7 @@ class PortfolioService:
             Dict: 処理結果とポートフォリオサマリー
         """
         # 全銘柄の最新株価を取得して更新
-        _, _ = await update_all_holdings_pl(self.db, user_id)
+        await update_all_holdings_pl(self.db, user_id)
 
         # ポートフォリオの状態を履歴に保存
         portfolio_history = await self.create_portfolio_history(user_id)

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -411,3 +411,42 @@ async def test_update_all_holdings_pl_returns_failed_symbols(
     assert "8058" not in failed_symbols
     # 日本株は更新成功している
     assert any(h.symbol == "8058" for h in holdings)
+
+
+@pytest.mark.asyncio
+async def test_update_all_holdings_pl_skips_zero_quantity(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_token: str,
+    setup_us_stock_data,
+    create_transaction,
+    mocker,
+):
+    """保有数ゼロの銘柄は価格取得自体をスキップし、失敗リストに含めないことを検証する。
+
+    AAPL を全量売却して quantity=0 にしたうえで、価格取得を 0.0（失敗）に固定しても
+    failed_symbols に AAPL が含まれないことを確認する。売却済み・上場廃止銘柄で
+    アラートが誤発火しないための回帰テスト。価格 / usd_price は損益計算結果に影響しないので
+    任意の妥当値を入れている。
+    """
+    sell_transaction = {
+        "symbol": "AAPL",
+        "transaction_type": "sell",
+        "quantity": "10.0",
+        "price": "37500",
+        "usd_price": "250.0",
+        "account_type": "NISA(成長投資枠)",
+        "fee": "0.0",
+        "tax": "0.0",
+        "transaction_date": "2024-02-01T00:00:00",
+    }
+    await create_transaction(sell_transaction)
+
+    mocker.patch("stock.services.holding_service.get_us_stock_price", return_value=0.0)
+
+    result = await db_session.execute(select(User).where(User.username == "testuser"))
+    user_id = result.scalar_one().user_id
+
+    _, failed_symbols = await update_all_holdings_pl(db_session, user_id)
+
+    assert "AAPL" not in failed_symbols

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -3,7 +3,8 @@ from httpx import AsyncClient
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stock.models import Holding
+from stock.models import Holding, User
+from stock.services.holding_service import update_all_holdings_pl
 from ..conftest import MOCK_JAPAN_STOCK_PRICE_UPDATED, MOCK_US_STOCK_PRICE_UPDATED, MOCK_USD_JPY_RATE_RESPONSE
 
 
@@ -381,3 +382,32 @@ async def test_update_holding_note_not_found(client: AsyncClient, auth_token: st
         json={"note": "test"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_all_holdings_pl_returns_failed_symbols(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_token: str,
+    setup_japanese_stock_data,
+    setup_us_stock_data,
+    mocker,
+):
+    """update_all_holdings_pl が価格取得失敗銘柄リストを第2要素として返すことを検証する。
+
+    米国株(AAPL)の価格取得を 0.0（取得失敗）に固定し、戻り値の失敗リストに含まれることを確認する。
+    日本株(8058)はデフォルトのモックで取得成功するため失敗リストに含まれない。
+    """
+    # 米国株の価格取得を失敗させる
+    mocker.patch("stock.services.holding_service.get_us_stock_price", return_value=0.0)
+
+    # auth_token フィクスチャで作成済みのテストユーザ ID を取得
+    result = await db_session.execute(select(User).where(User.username == "testuser"))
+    user_id = result.scalar_one().user_id
+
+    holdings, failed_symbols = await update_all_holdings_pl(db_session, user_id)
+
+    assert "AAPL" in failed_symbols
+    assert "8058" not in failed_symbols
+    # 日本株は更新成功している
+    assert any(h.symbol == "8058" for h in holdings)

--- a/src/api/tests/jobs/test_runner.py
+++ b/src/api/tests/jobs/test_runner.py
@@ -1,67 +1,8 @@
-"""ジョブランナー (_runner.py) のサマリログ出力をテストする。
-
-DBやセッション依存のテストは既存の API テスト経由で担保されているため、
-ここでは集計後のサマリログ整形ロジックに絞ってテストする。
-"""
+"""ジョブランナー (_runner.py) のサマリログ出力をテストする。"""
 
 import pytest
 
 from stock.jobs._runner import MAX_FAILED_SYMBOLS_IN_LOG, _log_summary
-
-
-def test_log_summary_no_failures(mocker):
-    """失敗が0件のときは info レベルでサマリを出力する"""
-    mock_logger = mocker.patch("stock.jobs._runner.logger")
-
-    _log_summary("test_job", target_users=3, failure_count=0, failed_symbols=set())
-
-    mock_logger.info.assert_called_once()
-    mock_logger.error.assert_not_called()
-    args = mock_logger.info.call_args.args
-    # フォーマット文字列の引数として target_users / failed_symbol_count などが渡る
-    assert "test_job" in args
-    assert 3 in args  # target_users
-    assert 0 in args  # failed_symbol_count
-
-
-def test_log_summary_with_failed_symbols(mocker):
-    """失敗銘柄があるときは error レベル、ソート済みリストで出力する"""
-    mock_logger = mocker.patch("stock.jobs._runner.logger")
-
-    _log_summary("test_job", target_users=2, failure_count=0, failed_symbols={"MSFT", "AAPL"})
-
-    mock_logger.error.assert_called_once()
-    mock_logger.info.assert_not_called()
-    args = mock_logger.error.call_args.args
-    # 失敗銘柄リストはソート済みで渡る
-    assert ["AAPL", "MSFT"] in args
-    assert 2 in args  # failed_symbol_count
-
-
-def test_log_summary_with_user_failure_only(mocker):
-    """銘柄失敗ゼロでもユーザー単位の失敗があれば error レベルで出力する"""
-    mock_logger = mocker.patch("stock.jobs._runner.logger")
-
-    _log_summary("test_job", target_users=2, failure_count=1, failed_symbols=set())
-
-    mock_logger.error.assert_called_once()
-    mock_logger.info.assert_not_called()
-
-
-def test_log_summary_truncates_when_over_limit(mocker):
-    """失敗銘柄が上限を超えたら配列を切り詰めて省略件数を併記する"""
-    mock_logger = mocker.patch("stock.jobs._runner.logger")
-    failed = {f"SYM{i:03d}" for i in range(MAX_FAILED_SYMBOLS_IN_LOG + 10)}
-
-    _log_summary("test_job", target_users=1, failure_count=0, failed_symbols=failed)
-
-    args = mock_logger.error.call_args.args
-    # 引数中の list (failed_symbols) は切り詰められている
-    truncated_lists = [a for a in args if isinstance(a, list)]
-    assert len(truncated_lists) == 1
-    assert len(truncated_lists[0]) == MAX_FAILED_SYMBOLS_IN_LOG
-    # 省略件数 10 が引数に含まれる
-    assert 10 in args
 
 
 @pytest.mark.parametrize(
@@ -88,3 +29,27 @@ def test_log_summary_level_selection(mocker, failure_count, failed_symbols, expe
     not_expected = mock_logger.info if expected_level == "error" else mock_logger.error
     expected.assert_called_once()
     not_expected.assert_not_called()
+
+
+def test_log_summary_sorts_symbols(mocker):
+    """失敗銘柄リストはソート済みで出力される"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+
+    _log_summary("test_job", target_users=2, failure_count=0, failed_symbols={"MSFT", "AAPL"})
+
+    args = mock_logger.error.call_args.args
+    assert ["AAPL", "MSFT"] in args
+
+
+def test_log_summary_truncates_when_over_limit(mocker):
+    """失敗銘柄が上限を超えたら配列を切り詰めて省略件数を併記する"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+    failed = {f"SYM{i:03d}" for i in range(MAX_FAILED_SYMBOLS_IN_LOG + 10)}
+
+    _log_summary("test_job", target_users=1, failure_count=0, failed_symbols=failed)
+
+    args = mock_logger.error.call_args.args
+    truncated_lists = [a for a in args if isinstance(a, list)]
+    assert len(truncated_lists) == 1
+    assert len(truncated_lists[0]) == MAX_FAILED_SYMBOLS_IN_LOG
+    assert 10 in args  # 省略件数

--- a/src/api/tests/jobs/test_runner.py
+++ b/src/api/tests/jobs/test_runner.py
@@ -1,0 +1,90 @@
+"""ジョブランナー (_runner.py) のサマリログ出力をテストする。
+
+DBやセッション依存のテストは既存の API テスト経由で担保されているため、
+ここでは集計後のサマリログ整形ロジックに絞ってテストする。
+"""
+
+import pytest
+
+from stock.jobs._runner import MAX_FAILED_SYMBOLS_IN_LOG, _log_summary
+
+
+def test_log_summary_no_failures(mocker):
+    """失敗が0件のときは info レベルでサマリを出力する"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+
+    _log_summary("test_job", target_users=3, failure_count=0, failed_symbols=set())
+
+    mock_logger.info.assert_called_once()
+    mock_logger.error.assert_not_called()
+    args = mock_logger.info.call_args.args
+    # フォーマット文字列の引数として target_users / failed_symbol_count などが渡る
+    assert "test_job" in args
+    assert 3 in args  # target_users
+    assert 0 in args  # failed_symbol_count
+
+
+def test_log_summary_with_failed_symbols(mocker):
+    """失敗銘柄があるときは error レベル、ソート済みリストで出力する"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+
+    _log_summary("test_job", target_users=2, failure_count=0, failed_symbols={"MSFT", "AAPL"})
+
+    mock_logger.error.assert_called_once()
+    mock_logger.info.assert_not_called()
+    args = mock_logger.error.call_args.args
+    # 失敗銘柄リストはソート済みで渡る
+    assert ["AAPL", "MSFT"] in args
+    assert 2 in args  # failed_symbol_count
+
+
+def test_log_summary_with_user_failure_only(mocker):
+    """銘柄失敗ゼロでもユーザー単位の失敗があれば error レベルで出力する"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+
+    _log_summary("test_job", target_users=2, failure_count=1, failed_symbols=set())
+
+    mock_logger.error.assert_called_once()
+    mock_logger.info.assert_not_called()
+
+
+def test_log_summary_truncates_when_over_limit(mocker):
+    """失敗銘柄が上限を超えたら配列を切り詰めて省略件数を併記する"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+    failed = {f"SYM{i:03d}" for i in range(MAX_FAILED_SYMBOLS_IN_LOG + 10)}
+
+    _log_summary("test_job", target_users=1, failure_count=0, failed_symbols=failed)
+
+    args = mock_logger.error.call_args.args
+    # 引数中の list (failed_symbols) は切り詰められている
+    truncated_lists = [a for a in args if isinstance(a, list)]
+    assert len(truncated_lists) == 1
+    assert len(truncated_lists[0]) == MAX_FAILED_SYMBOLS_IN_LOG
+    # 省略件数 10 が引数に含まれる
+    assert 10 in args
+
+
+@pytest.mark.parametrize(
+    "failure_count,failed_symbols,expected_level",
+    [
+        (0, set(), "info"),
+        (1, set(), "error"),
+        (0, {"AAPL"}, "error"),
+        (2, {"AAPL", "MSFT"}, "error"),
+    ],
+)
+def test_log_summary_level_selection(mocker, failure_count, failed_symbols, expected_level):
+    """失敗の有無で info / error が切り替わる"""
+    mock_logger = mocker.patch("stock.jobs._runner.logger")
+
+    _log_summary(
+        "test_job",
+        target_users=1,
+        failure_count=failure_count,
+        failed_symbols=failed_symbols,
+    )
+
+    expected = mock_logger.error if expected_level == "error" else mock_logger.info
+    not_expected = mock_logger.info if expected_level == "error" else mock_logger.error
+    expected.assert_called_once()
+    not_expected.assert_not_called()


### PR DESCRIPTION
米国株の株価取得失敗を見逃さないよう、保有銘柄ごとの価格取得失敗をジョブ末尾に集約して構造化ログ出力し、失敗が1件でもあれば exit 1 で終了する。Cloud Monitoring が Cloud Run Jobs の失敗を検知して管理者にメール通知する仕組みを追加した。

- holding_service: calculate_holding_pl の戻り値を HoldingUpdateResult NamedTuple に。update_all_holdings_pl は失敗銘柄リストも返す
- _runner.py: UserAction を Optional 戻り値に拡張。失敗銘柄をユーザ横断でユニーク集約してサマリログ出力。50件超は省略
- recalc_holdings: 失敗銘柄リストをランナーに伝播
- infra/monitoring.tf: completed_execution_count{result=failed} を監視するアラートポリシーと email 通知チャネルを追加

https://claude.ai/code/session_01HnDp7mrb7ioKinp3tjub6Z