### PR TITLE
feat(web): ダッシュボード騰落率ランキングの銘柄名から詳細ページへ遷移できるようにする

### DIFF
--- a/src/web/src/components/dashboard/weekly-performance-card.test.tsx
+++ b/src/web/src/components/dashboard/weekly-performance-card.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router"
 import { describe, expect, it } from "vitest"
 import type { StockWeeklyPerformance } from "@/lib/api/types"
 import { WeeklyPerformanceCard } from "./weekly-performance-card"
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
 
 const mockTopPerformers: StockWeeklyPerformance[] = [
   { symbol: "7203", name: "トヨタ自動車", latest_price: 3300, old_price: 3000, change_rate: 10.0 },
@@ -14,7 +19,9 @@ const mockBottomPerformers: StockWeeklyPerformance[] = [
 
 describe("WeeklyPerformanceCard", () => {
   it("direction=top のとき値上がりタイトルと銘柄リストが表示されること", () => {
-    render(<WeeklyPerformanceCard performers={mockTopPerformers} direction="top" isLoading={false} />)
+    renderWithRouter(
+      <WeeklyPerformanceCard performers={mockTopPerformers} direction="top" isLoading={false} />
+    )
 
     expect(screen.getByText("今週の値上がりトップ5")).toBeInTheDocument()
     expect(screen.getByText("トヨタ自動車")).toBeInTheDocument()
@@ -23,8 +30,21 @@ describe("WeeklyPerformanceCard", () => {
     expect(screen.getByText("三菱商事")).toBeInTheDocument()
   })
 
+  it("銘柄名が各銘柄の詳細ページへのリンクになっていること", () => {
+    renderWithRouter(
+      <WeeklyPerformanceCard performers={mockTopPerformers} direction="top" isLoading={false} />
+    )
+
+    const toyotaLink = screen.getByText("トヨタ自動車").closest("a")
+    expect(toyotaLink).toHaveAttribute("href", "/holdings/7203")
+    const mitsubishiLink = screen.getByText("三菱商事").closest("a")
+    expect(mitsubishiLink).toHaveAttribute("href", "/holdings/8058")
+  })
+
   it("direction=bottom のとき値下がりタイトルと負の騰落率が表示されること", () => {
-    render(<WeeklyPerformanceCard performers={mockBottomPerformers} direction="bottom" isLoading={false} />)
+    renderWithRouter(
+      <WeeklyPerformanceCard performers={mockBottomPerformers} direction="bottom" isLoading={false} />
+    )
 
     expect(screen.getByText("今週の値下がりトップ5")).toBeInTheDocument()
     expect(screen.getByText("任天堂")).toBeInTheDocument()
@@ -32,13 +52,13 @@ describe("WeeklyPerformanceCard", () => {
   })
 
   it("performersが空配列のときフォールバック文言が表示されること", () => {
-    render(<WeeklyPerformanceCard performers={[]} direction="top" isLoading={false} />)
+    renderWithRouter(<WeeklyPerformanceCard performers={[]} direction="top" isLoading={false} />)
 
     expect(screen.getByText("表示できる銘柄がありません")).toBeInTheDocument()
   })
 
   it("ローディング中にスケルトンが表示されること", () => {
-    render(<WeeklyPerformanceCard performers={undefined} direction="top" isLoading={true} />)
+    renderWithRouter(<WeeklyPerformanceCard performers={undefined} direction="top" isLoading={true} />)
 
     expect(screen.getByText("今週の値上がりトップ5")).toBeInTheDocument()
     const skeleton = screen.getByText("今週の値上がりトップ5").closest("div")?.parentElement

--- a/src/web/src/components/dashboard/weekly-performance-card.tsx
+++ b/src/web/src/components/dashboard/weekly-performance-card.tsx
@@ -1,4 +1,5 @@
 import { TrendingDown, TrendingUp } from "lucide-react"
+import { Link } from "react-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { StockWeeklyPerformance } from "@/lib/api/types"
 import { formatPercent, getPLColorClass } from "@/lib/format"
@@ -29,10 +30,10 @@ function PerformerList({ performers }: { performers: StockWeeklyPerformance[] })
         <li key={p.symbol} className="flex items-center justify-between gap-3 border-b py-2 last:border-b-0">
           <div className="flex min-w-0 items-center gap-3">
             <span className="w-5 shrink-0 text-sm text-muted-foreground">{index + 1}</span>
-            <div className="min-w-0">
+            <Link to={`/holdings/${p.symbol}`} className="min-w-0 hover:opacity-80">
               <p className="truncate text-sm font-medium">{p.name}</p>
               <p className="text-xs text-muted-foreground">{p.symbol}</p>
-            </div>
+            </Link>
           </div>
           <span className={`shrink-0 font-bold ${getPLColorClass(p.change_rate)}`}>
             {formatPercent(p.change_rate)}

--- a/src/web/src/components/dashboard/weekly-performance-card.tsx
+++ b/src/web/src/components/dashboard/weekly-performance-card.tsx
@@ -31,7 +31,7 @@ function PerformerList({ performers }: { performers: StockWeeklyPerformance[] })
           <div className="flex min-w-0 items-center gap-3">
             <span className="w-5 shrink-0 text-sm text-muted-foreground">{index + 1}</span>
             <Link to={`/holdings/${p.symbol}`} className="min-w-0 hover:opacity-80">
-              <p className="truncate text-sm font-medium">{p.name}</p>
+              <p className="truncate text-sm font-medium hover:underline">{p.name}</p>
               <p className="text-xs text-muted-foreground">{p.symbol}</p>
             </Link>
           </div>


### PR DESCRIPTION
https://claude.ai/code/session_01GsmQS7ammiKZjt5gcMoP9T