### PR TITLE
セクター別ツリーマップコンポーネントを追加

### DIFF
--- a/src/api/stock/schemas.py
+++ b/src/api/stock/schemas.py
@@ -178,6 +178,8 @@ class Holding(HoldingBase):
     stock_name: Optional[str] = None
     security_type: Optional[str] = None
     currency: Optional[str] = None
+    country: Optional[str] = None
+    sector_name: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
 
     @field_serializer("last_updated")

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -470,7 +470,7 @@ def _derive_country_and_sector(stock: Stock) -> tuple[Optional[str], Optional[st
     return country, sector_name
 
 
-async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> List[Holding]:
+async def list_holdings(db: AsyncSession, user_id: int, symbol: Optional[str] = None) -> List[Holding]:
     """
     ユーザーの保有銘柄一覧を銘柄名、証券種別、通貨、国、セクターと共に取得します。
     symbolが指定された場合は、その銘柄の情報のみを返します。

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -446,9 +446,33 @@ async def update_all_holdings_pl(
     return updated_holdings, sorted(failed_symbols)
 
 
+def _derive_country_and_sector(stock: Stock) -> tuple[Optional[str], Optional[str]]:
+    """Stock から国 (JP/US/OTHER) とセクター名を導出する。
+
+    - 投信 (security_type=="FUND") は国際分散のため "OTHER" に集約
+    - JPY 建ては "JP"、USD 建ては "US"、その他は "OTHER"
+    - セクター名は JPX 17 業種または GICS セクター。詳細レコードが無い場合は None
+    """
+    if stock.security_type == "FUND":
+        country: Optional[str] = "OTHER"
+    elif stock.currency == "JPY":
+        country = "JP"
+    elif stock.currency == "USD":
+        country = "US"
+    else:
+        country = "OTHER"
+
+    sector_name: Optional[str] = None
+    if stock.jpx_detail is not None:
+        sector_name = stock.jpx_detail.sector_17_name
+    elif stock.us_detail is not None:
+        sector_name = stock.us_detail.gics_sector
+    return country, sector_name
+
+
 async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> List[Holding]:
     """
-    ユーザーの保有銘柄一覧を銘柄名、証券種別、通貨と共に取得します。
+    ユーザーの保有銘柄一覧を銘柄名、証券種別、通貨、国、セクターと共に取得します。
     symbolが指定された場合は、その銘柄の情報のみを返します。
 
     Args:
@@ -457,9 +481,16 @@ async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> L
         symbol (str, optional): 銘柄コード。指定された場合はその銘柄の情報のみを返します。
 
     Returns:
-        List[Holding]: 銘柄名、証券種別、通貨を含む保有銘柄情報のリスト
+        List[Holding]: 銘柄名、証券種別、通貨、国、セクター名を含む保有銘柄情報のリスト
     """
-    query = select(Holding).options(selectinload(Holding.stock)).where(Holding.user_id == user_id)
+    query = (
+        select(Holding)
+        .options(
+            selectinload(Holding.stock).selectinload(Stock.jpx_detail),
+            selectinload(Holding.stock).selectinload(Stock.us_detail),
+        )
+        .where(Holding.user_id == user_id)
+    )
 
     # symbolが指定された場合は、条件を追加
     if symbol:
@@ -471,6 +502,7 @@ async def list_holdings(db: AsyncSession, user_id: int, symbol: str = None) -> L
         holding.stock_name = holding.stock.name
         holding.security_type = holding.stock.security_type
         holding.currency = holding.stock.currency
+        holding.country, holding.sector_name = _derive_country_and_sector(holding.stock)
     logger.info(
         "Holdingsを取得しました action=select user_id={} symbol={} count={}",
         user_id,

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stock.models import Holding, User
+from stock.models import Holding, StockJPXDetail, StockUSDetail, User
 from stock.services.holding_service import update_all_holdings_pl
 from ..conftest import MOCK_JAPAN_STOCK_PRICE_UPDATED, MOCK_US_STOCK_PRICE_UPDATED, MOCK_USD_JPY_RATE_RESPONSE
 
@@ -101,6 +101,60 @@ async def test_list_holdings(
     assert data[0]["stock_name"] == "三菱商事"
     assert data[0]["security_type"] == "STOCK"
     assert data[0]["currency"] == "JPY"
+    # JPY建ての日本株は country=="JP"。詳細レコードが無いため sector_name は None
+    assert data[0]["country"] == "JP"
+    assert data[0]["sector_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_holdings_returns_sector_name_for_jp(
+    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_japanese_stock_data
+):
+    """StockJPXDetail が存在する日本株は country=="JP" / sector_name に 17 業種名が入る"""
+    db_session.add(
+        StockJPXDetail(
+            symbol="8058",
+            sector_17_code="04",
+            sector_17_name="商社・卸売",
+            market_segment="プライム",
+        )
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/v1/holdings/")
+
+    assert response.status_code == 200
+    data = response.json()
+    target = next(h for h in data if h["symbol"] == "8058")
+    assert target["country"] == "JP"
+    assert target["sector_name"] == "商社・卸売"
+
+
+@pytest.mark.asyncio
+async def test_list_holdings_returns_country_and_sector_for_us(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_token: str,
+    setup_us_stock_data,
+    mock_external_apis,
+):
+    """USD建ての米国株は country=="US"、StockUSDetail.gics_sector が sector_name に入る"""
+    db_session.add(
+        StockUSDetail(
+            symbol="AAPL",
+            gics_sector="Information Technology",
+            market="NASDAQ",
+        )
+    )
+    await db_session.commit()
+
+    response = await client.get("/api/v1/holdings/")
+
+    assert response.status_code == 200
+    data = response.json()
+    target = next(h for h in data if h["symbol"] == "AAPL")
+    assert target["country"] == "US"
+    assert target["sector_name"] == "Information Technology"
 
 
 @pytest.mark.asyncio

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stock.models import Holding, StockJPXDetail, StockUSDetail, User
+from stock.models import Holding, User
 from stock.services.holding_service import update_all_holdings_pl
 from ..conftest import MOCK_JAPAN_STOCK_PRICE_UPDATED, MOCK_US_STOCK_PRICE_UPDATED, MOCK_USD_JPY_RATE_RESPONSE
 
@@ -101,60 +101,23 @@ async def test_list_holdings(
     assert data[0]["stock_name"] == "三菱商事"
     assert data[0]["security_type"] == "STOCK"
     assert data[0]["currency"] == "JPY"
-    # JPY建ての日本株は country=="JP"。詳細レコードが無いため sector_name は None
+    # JPY建ての日本株は country=="JP"、JQuants から取得した 17 業種名が sector_name に入る
     assert data[0]["country"] == "JP"
-    assert data[0]["sector_name"] is None
-
-
-@pytest.mark.asyncio
-async def test_list_holdings_returns_sector_name_for_jp(
-    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_japanese_stock_data
-):
-    """StockJPXDetail が存在する日本株は country=="JP" / sector_name に 17 業種名が入る"""
-    db_session.add(
-        StockJPXDetail(
-            symbol="8058",
-            sector_17_code="04",
-            sector_17_name="商社・卸売",
-            market_segment="プライム",
-        )
-    )
-    await db_session.commit()
-
-    response = await client.get("/api/v1/holdings/")
-
-    assert response.status_code == 200
-    data = response.json()
-    target = next(h for h in data if h["symbol"] == "8058")
-    assert target["country"] == "JP"
-    assert target["sector_name"] == "商社・卸売"
+    assert data[0]["sector_name"] == "商社・卸売"
 
 
 @pytest.mark.asyncio
 async def test_list_holdings_returns_country_and_sector_for_us(
-    client: AsyncClient,
-    db_session: AsyncSession,
-    auth_token: str,
-    setup_us_stock_data,
-    mock_external_apis,
+    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_us_stock_data
 ):
-    """USD建ての米国株は country=="US"、StockUSDetail.gics_sector が sector_name に入る"""
-    db_session.add(
-        StockUSDetail(
-            symbol="AAPL",
-            gics_sector="Information Technology",
-            market="NASDAQ",
-        )
-    )
-    await db_session.commit()
-
+    """USD建ての米国株は country=="US"、AlphaVantage から取得した gics_sector が sector_name に入る"""
     response = await client.get("/api/v1/holdings/")
 
     assert response.status_code == 200
     data = response.json()
     target = next(h for h in data if h["symbol"] == "AAPL")
     assert target["country"] == "US"
-    assert target["sector_name"] == "Information Technology"
+    assert target["sector_name"] == "Consumer Electronics"
 
 
 @pytest.mark.asyncio

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -117,7 +117,7 @@ async def test_list_holdings_returns_country_and_sector_for_us(
     data = response.json()
     target = next(h for h in data if h["symbol"] == "AAPL")
     assert target["country"] == "US"
-    assert target["sector_name"] == "Consumer Electronics"
+    assert target["sector_name"] == "Technology"
 
 
 @pytest.mark.asyncio

--- a/src/web/src/components/dashboard/dashboard.tsx
+++ b/src/web/src/components/dashboard/dashboard.tsx
@@ -3,6 +3,7 @@ import useSWR from "swr"
 import { Button } from "@/components/ui/button"
 import {
   getDividendsMonthly,
+  getHoldings,
   getPortfolioHistory,
   getPortfolioSummary,
   getTransactionsMonthlySummary,
@@ -11,6 +12,7 @@ import {
 import { AssetChart } from "./asset-chart"
 import { DividendChart } from "./dividend-chart"
 import { NisaLimitGauge } from "./nisa-limit-gauge"
+import { SectorTreemap } from "./sector-treemap"
 import { StatCards } from "./stat-cards"
 import { TradeChart } from "./trade-chart"
 import { WeeklyPerformanceCard } from "./weekly-performance-card"
@@ -46,8 +48,19 @@ export function Dashboard() {
     mutate: mutateWeeklyPerformance,
   } = useSWR("weekly-performance", getWeeklyPerformance)
 
+  const {
+    data: holdings,
+    isLoading: holdingsLoading,
+    mutate: mutateHoldings,
+  } = useSWR("holdings", getHoldings)
+
   const isRefreshing =
-    summaryLoading || historyLoading || tradesLoading || dividendsLoading || weeklyPerformanceLoading
+    summaryLoading ||
+    historyLoading ||
+    tradesLoading ||
+    dividendsLoading ||
+    weeklyPerformanceLoading ||
+    holdingsLoading
 
   const handleRefresh = () => {
     mutateSummary()
@@ -55,6 +68,7 @@ export function Dashboard() {
     mutateTrades()
     mutateDividends()
     mutateWeeklyPerformance()
+    mutateHoldings()
   }
 
   return (
@@ -69,6 +83,7 @@ export function Dashboard() {
       <StatCards summary={summary} isLoading={summaryLoading} />
       <NisaLimitGauge data={trades} isLoading={tradesLoading} />
       <AssetChart history={history} isLoading={historyLoading} />
+      <SectorTreemap data={holdings} isLoading={holdingsLoading} />
       <div className="grid gap-6 lg:grid-cols-2">
         <WeeklyPerformanceCard
           performers={weeklyPerformance?.top_performers}

--- a/src/web/src/components/dashboard/dashboard.tsx
+++ b/src/web/src/components/dashboard/dashboard.tsx
@@ -52,7 +52,7 @@ export function Dashboard() {
     data: holdings,
     isLoading: holdingsLoading,
     mutate: mutateHoldings,
-  } = useSWR("holdings", getHoldings)
+  } = useSWR("/api/v1/holdings/", getHoldings)
 
   const isRefreshing =
     summaryLoading ||

--- a/src/web/src/components/dashboard/dashboard.tsx
+++ b/src/web/src/components/dashboard/dashboard.tsx
@@ -83,7 +83,9 @@ export function Dashboard() {
       <StatCards summary={summary} isLoading={summaryLoading} />
       <NisaLimitGauge data={trades} isLoading={tradesLoading} />
       <AssetChart history={history} isLoading={historyLoading} />
-      <SectorTreemap data={holdings} isLoading={holdingsLoading} />
+      <div className="hidden md:block">
+        <SectorTreemap data={holdings} isLoading={holdingsLoading} />
+      </div>
       <div className="grid gap-6 lg:grid-cols-2">
         <WeeklyPerformanceCard
           performers={weeklyPerformance?.top_performers}

--- a/src/web/src/components/dashboard/holding-allocation-chart.test.ts
+++ b/src/web/src/components/dashboard/holding-allocation-chart.test.ts
@@ -26,6 +26,8 @@ describe("transformHoldingsToChartData", () => {
     stock_name: stockName,
     security_type: securityType,
     currency: "JPY",
+    country: null,
+    sector_name: null,
     note: null,
   })
 

--- a/src/web/src/components/dashboard/holding-allocation-chart.test.ts
+++ b/src/web/src/components/dashboard/holding-allocation-chart.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Holding } from "@/lib/api/types"
+import { createHolding as createHoldingBase } from "@/test/factories"
 import { transformHoldingsToChartData } from "./holding-allocation-chart"
 
 describe("transformHoldingsToChartData", () => {
@@ -8,28 +9,13 @@ describe("transformHoldingsToChartData", () => {
     marketValue: number,
     stockName: string | null = null,
     securityType: string | null = "STOCK"
-  ): Holding => ({
-    symbol,
-    quantity: 100,
-    average_cost: 1000,
-    total_cost: 100000,
-    current_price: 1100,
-    market_value: marketValue,
-    realized_pl: 0,
-    total_dividend: 0,
-    unrealized_pl: 10000,
-    unrealized_pl_percentage: 10,
-    total_pl: 10000,
-    total_pl_percentage: 10,
-    user_id: 1,
-    last_updated: "2024-01-01",
-    stock_name: stockName,
-    security_type: securityType,
-    currency: "JPY",
-    country: null,
-    sector_name: null,
-    note: null,
-  })
+  ): Holding =>
+    createHoldingBase({
+      symbol,
+      market_value: marketValue,
+      stock_name: stockName,
+      security_type: securityType,
+    })
 
   it("上位20銘柄を個別に表示する", () => {
     const holdings: Holding[] = Array.from({ length: 15 }, (_, i) =>

--- a/src/web/src/components/dashboard/holding-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/holding-allocation-chart.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Holding } from "@/lib/api/types"
 import { formatCurrency } from "@/lib/format"
+import { SECURITY_TYPE_FILTERS, type SecurityTypeFilter } from "@/lib/security-type"
 
 interface HoldingAllocationChartProps {
   data: Holding[] | undefined
@@ -36,18 +37,6 @@ const COLORS = [
 
 // 「その他」用の色
 const OTHER_COLOR = "#BDBDBD"
-
-// フィルタータイプ
-type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
-
-// フィルタボタンの設定
-const FILTER_OPTIONS: { value: SecurityTypeFilter; label: string }[] = [
-  { value: "ALL", label: "すべて" },
-  { value: "STOCK", label: "株式" },
-  { value: "ETF", label: "ETF" },
-  { value: "FUND", label: "投信" },
-  { value: "REIT", label: "REIT" },
-]
 
 interface ChartDataItem {
   name: string
@@ -120,7 +109,7 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
 
   // フィルタに応じたタイトルを生成
   const chartTitle = useMemo(() => {
-    const filterLabel = FILTER_OPTIONS.find((option) => option.value === filter)?.label || "すべて"
+    const filterLabel = SECURITY_TYPE_FILTERS.find((option) => option.value === filter)?.label || "すべて"
     return filter === "ALL" ? "銘柄別保有割合" : `${filterLabel}の銘柄別保有割合`
   }, [filter])
 
@@ -142,7 +131,7 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
       <CardHeader>
         <CardTitle>{chartTitle}</CardTitle>
         <div className="mt-4 flex flex-wrap gap-2">
-          {FILTER_OPTIONS.map((option) => (
+          {SECURITY_TYPE_FILTERS.map((option) => (
             <Button
               key={option.value}
               variant={filter === option.value ? "default" : "outline"}

--- a/src/web/src/components/dashboard/sector-treemap.test.tsx
+++ b/src/web/src/components/dashboard/sector-treemap.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router"
+import { describe, expect, it } from "vitest"
+import type { Holding } from "@/lib/api/types"
+import { flattenColorValues, SectorTreemap, transformHoldingsToTreemap } from "./sector-treemap"
+
+const createHolding = (overrides: Partial<Holding>): Holding => ({
+  symbol: "TEST",
+  quantity: 100,
+  average_cost: 1000,
+  total_cost: 100000,
+  current_price: 1100,
+  market_value: 110000,
+  realized_pl: 0,
+  total_dividend: 0,
+  unrealized_pl: 10000,
+  unrealized_pl_percentage: 10,
+  total_pl: 10000,
+  total_pl_percentage: 10,
+  user_id: 1,
+  last_updated: "2024-01-01",
+  stock_name: "テスト",
+  security_type: "STOCK",
+  currency: "JPY",
+  country: "JP",
+  sector_name: "情報・通信業",
+  note: null,
+  ...overrides,
+})
+
+describe("transformHoldingsToTreemap", () => {
+  it("空配列を渡すと空配列を返す", () => {
+    expect(transformHoldingsToTreemap([], { country: "ALL", securityType: "ALL" })).toEqual([])
+    expect(transformHoldingsToTreemap(undefined, { country: "ALL", securityType: "ALL" })).toEqual([])
+  })
+
+  it("国 → セクター → 銘柄の3階層構造に集約される", () => {
+    const holdings: Holding[] = [
+      createHolding({
+        symbol: "8058",
+        stock_name: "三菱商事",
+        country: "JP",
+        sector_name: "商社・卸売",
+        market_value: 300000,
+      }),
+      createHolding({
+        symbol: "7203",
+        stock_name: "トヨタ",
+        country: "JP",
+        sector_name: "自動車・輸送機",
+        market_value: 200000,
+      }),
+      createHolding({
+        symbol: "AAPL",
+        stock_name: "Apple",
+        country: "US",
+        sector_name: "Information Technology",
+        currency: "USD",
+        market_value: 800000,
+      }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ALL" })
+
+    // 評価額降順なので US が先
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe("米国")
+    expect(result[1].name).toBe("日本")
+    // JP の中に 2 セクター
+    expect(result[1].children).toHaveLength(2)
+  })
+
+  it("country が null の銘柄は OTHER に集約される", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "X1", country: null, sector_name: null, market_value: 100000 }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ALL" })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("その他")
+    expect(result[0].children[0].name).toBe("その他")
+  })
+
+  it("market_value が 0 以下の銘柄は除外される", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "ZERO", market_value: 0 }),
+      createHolding({ symbol: "NEG", market_value: -100 }),
+      createHolding({ symbol: "NULL", market_value: null }),
+      createHolding({ symbol: "OK", market_value: 100000 }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ALL" })
+    const leaves = result.flatMap((c) => c.children.flatMap((s) => s.children))
+    expect(leaves).toHaveLength(1)
+  })
+
+  it("国フィルタが効く", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "JP1", country: "JP" }),
+      createHolding({ symbol: "US1", country: "US" }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "JP", securityType: "ALL" })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("日本")
+  })
+
+  it("証券種別フィルタが効く", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "S", security_type: "STOCK" }),
+      createHolding({ symbol: "E", security_type: "ETF" }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ETF" })
+    const leaves = result.flatMap((c) => c.children.flatMap((s) => s.children))
+    expect(leaves).toHaveLength(1)
+    expect(leaves[0].symbol).toBe("E")
+  })
+
+  it("セクター内の銘柄が評価額降順でソートされる", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "SMALL", market_value: 100000, sector_name: "情報・通信業" }),
+      createHolding({ symbol: "LARGE", market_value: 500000, sector_name: "情報・通信業" }),
+      createHolding({ symbol: "MID", market_value: 300000, sector_name: "情報・通信業" }),
+    ]
+    const result = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ALL" })
+    const leaves = result[0].children[0].children
+    expect(leaves.map((l) => l.symbol)).toEqual(["LARGE", "MID", "SMALL"])
+  })
+})
+
+describe("flattenColorValues", () => {
+  it("葉のplPercentageを平らに取り出す", () => {
+    const holdings: Holding[] = [
+      createHolding({ symbol: "A", unrealized_pl_percentage: 10 }),
+      createHolding({ symbol: "B", unrealized_pl_percentage: -5, country: "US", sector_name: "X" }),
+    ]
+    const data = transformHoldingsToTreemap(holdings, { country: "ALL", securityType: "ALL" })
+    const values = flattenColorValues(data)
+    expect(values.sort()).toEqual([-5, 10])
+  })
+})
+
+describe("SectorTreemap (rendering)", () => {
+  function renderWithRouter(ui: React.ReactElement) {
+    return render(<MemoryRouter>{ui}</MemoryRouter>)
+  }
+
+  it("ローディング中はスケルトンを表示する", () => {
+    renderWithRouter(<SectorTreemap data={undefined} isLoading={true} />)
+    expect(screen.getByText("セクター別ツリーマップ")).toBeInTheDocument()
+  })
+
+  it("データが無いときに「データがありません」を表示する", () => {
+    renderWithRouter(<SectorTreemap data={[]} isLoading={false} />)
+    expect(screen.getByText("データがありません")).toBeInTheDocument()
+  })
+
+  it("国フィルタボタンが表示される", () => {
+    renderWithRouter(<SectorTreemap data={[createHolding({ symbol: "T" })]} isLoading={false} />)
+    expect(screen.getByRole("button", { name: "日本" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "米国" })).toBeInTheDocument()
+  })
+})

--- a/src/web/src/components/dashboard/sector-treemap.test.tsx
+++ b/src/web/src/components/dashboard/sector-treemap.test.tsx
@@ -2,31 +2,11 @@ import { render, screen } from "@testing-library/react"
 import { MemoryRouter } from "react-router"
 import { describe, expect, it } from "vitest"
 import type { Holding } from "@/lib/api/types"
+import { createHolding as createHoldingBase } from "@/test/factories"
 import { flattenColorValues, SectorTreemap, transformHoldingsToTreemap } from "./sector-treemap"
 
-const createHolding = (overrides: Partial<Holding>): Holding => ({
-  symbol: "TEST",
-  quantity: 100,
-  average_cost: 1000,
-  total_cost: 100000,
-  current_price: 1100,
-  market_value: 110000,
-  realized_pl: 0,
-  total_dividend: 0,
-  unrealized_pl: 10000,
-  unrealized_pl_percentage: 10,
-  total_pl: 10000,
-  total_pl_percentage: 10,
-  user_id: 1,
-  last_updated: "2024-01-01",
-  stock_name: "テスト",
-  security_type: "STOCK",
-  currency: "JPY",
-  country: "JP",
-  sector_name: "情報・通信業",
-  note: null,
-  ...overrides,
-})
+const createHolding = (overrides: Partial<Holding> = {}): Holding =>
+  createHoldingBase({ country: "JP", sector_name: "情報・通信業", ...overrides })
 
 describe("transformHoldingsToTreemap", () => {
   it("空配列を渡すと空配列を返す", () => {

--- a/src/web/src/components/dashboard/sector-treemap.tsx
+++ b/src/web/src/components/dashboard/sector-treemap.tsx
@@ -7,7 +7,8 @@ import type { Holding } from "@/lib/api/types"
 import { type ColorScale, computeColorScale, getColorForValue } from "@/lib/color-scale"
 import { formatCurrency, formatPercent } from "@/lib/format"
 
-type CountryFilter = "ALL" | "JP" | "US" | "OTHER"
+type Country = "JP" | "US" | "OTHER"
+type CountryFilter = "ALL" | Country
 type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
 
 interface SectorTreemapProps {
@@ -20,29 +21,34 @@ interface TreemapLeaf {
   value: number
   symbol: string
   stockName: string
-  country: string
+  country: Country
   sectorName: string
   plPercentage: number | null
-  [key: string]: unknown
 }
 
 interface TreemapSector {
   name: string
   children: TreemapLeaf[]
-  [key: string]: unknown
+  value: number
 }
 
 interface TreemapCountry {
   name: string
   children: TreemapSector[]
-  [key: string]: unknown
+  value: number
+}
+
+const COUNTRY_LABELS: Record<Country, string> = {
+  JP: "日本",
+  US: "米国",
+  OTHER: "その他",
 }
 
 const COUNTRY_FILTERS: { value: CountryFilter; label: string }[] = [
   { value: "ALL", label: "すべて" },
-  { value: "JP", label: "日本" },
-  { value: "US", label: "米国" },
-  { value: "OTHER", label: "その他" },
+  { value: "JP", label: COUNTRY_LABELS.JP },
+  { value: "US", label: COUNTRY_LABELS.US },
+  { value: "OTHER", label: COUNTRY_LABELS.OTHER },
 ]
 
 const SECURITY_TYPE_FILTERS: { value: SecurityTypeFilter; label: string }[] = [
@@ -53,16 +59,15 @@ const SECURITY_TYPE_FILTERS: { value: SecurityTypeFilter; label: string }[] = [
   { value: "REIT", label: "REIT" },
 ]
 
-const COUNTRY_LABELS: Record<string, string> = {
-  JP: "日本",
-  US: "米国",
-  OTHER: "その他",
+function normalizeCountry(c: Holding["country"]): Country {
+  if (c === "JP" || c === "US") return c
+  return "OTHER"
 }
 
 /**
  * 保有銘柄を国 → セクター → 銘柄の3階層ツリーマップ用データに変換する。
  * 評価額（market_value）が 0 以下の銘柄、フィルタ条件に合わない銘柄は除外。
- * country/sector_name が null のものは "OTHER"/"その他" に集約する。
+ * country が null や未知の値、sector_name が null のものは "OTHER"/"その他" に集約する。
  */
 export function transformHoldingsToTreemap(
   holdings: Holding[] | undefined,
@@ -70,53 +75,50 @@ export function transformHoldingsToTreemap(
 ): TreemapCountry[] {
   if (!holdings || holdings.length === 0) return []
 
-  const filtered = holdings.filter((h) => {
-    if ((h.market_value ?? 0) <= 0) return false
-    const countryKey = h.country ?? "OTHER"
-    if (filters.country !== "ALL" && countryKey !== filters.country) return false
-    if (filters.securityType !== "ALL" && h.security_type !== filters.securityType) return false
-    return true
-  })
+  const byCountry = new Map<Country, Map<string, TreemapLeaf[]>>()
+  for (const h of holdings) {
+    if ((h.market_value ?? 0) <= 0) continue
+    const country = normalizeCountry(h.country)
+    if (filters.country !== "ALL" && country !== filters.country) continue
+    if (filters.securityType !== "ALL" && h.security_type !== filters.securityType) continue
 
-  const byCountry = new Map<string, Map<string, TreemapLeaf[]>>()
-  for (const h of filtered) {
-    const countryKey = h.country ?? "OTHER"
     const sectorKey = h.sector_name ?? "その他"
-    if (!byCountry.has(countryKey)) byCountry.set(countryKey, new Map())
-    const sectors = byCountry.get(countryKey)
-    if (!sectors) continue
-    if (!sectors.has(sectorKey)) sectors.set(sectorKey, [])
-    const leaves = sectors.get(sectorKey)
-    if (!leaves) continue
+    let sectors = byCountry.get(country)
+    if (!sectors) {
+      sectors = new Map()
+      byCountry.set(country, sectors)
+    }
+    let leaves = sectors.get(sectorKey)
+    if (!leaves) {
+      leaves = []
+      sectors.set(sectorKey, leaves)
+    }
     leaves.push({
       name: h.stock_name || h.symbol,
       value: h.market_value ?? 0,
       symbol: h.symbol,
       stockName: h.stock_name || h.symbol,
-      country: countryKey,
+      country,
       sectorName: sectorKey,
       plPercentage: h.unrealized_pl_percentage,
     })
   }
 
   const result: TreemapCountry[] = []
-  for (const [countryKey, sectors] of byCountry.entries()) {
+  for (const [country, sectors] of byCountry.entries()) {
     const sectorBranches: TreemapSector[] = []
+    let countryTotal = 0
     for (const [sectorName, leaves] of sectors.entries()) {
       leaves.sort((a, b) => b.value - a.value)
-      sectorBranches.push({ name: sectorName, children: leaves })
+      const sectorTotal = leaves.reduce((s, l) => s + l.value, 0)
+      sectorBranches.push({ name: sectorName, children: leaves, value: sectorTotal })
+      countryTotal += sectorTotal
     }
-    sectorBranches.sort((a, b) => sumLeafValues(b.children) - sumLeafValues(a.children))
-    result.push({ name: COUNTRY_LABELS[countryKey] ?? countryKey, children: sectorBranches })
+    sectorBranches.sort((a, b) => b.value - a.value)
+    result.push({ name: COUNTRY_LABELS[country], children: sectorBranches, value: countryTotal })
   }
-  const countryTotal = (c: TreemapCountry) =>
-    c.children.reduce((s, sec) => s + sumLeafValues(sec.children), 0)
-  result.sort((a, b) => countryTotal(b) - countryTotal(a))
+  result.sort((a, b) => b.value - a.value)
   return result
-}
-
-function sumLeafValues(leaves: TreemapLeaf[]): number {
-  return leaves.reduce((sum, l) => sum + l.value, 0)
 }
 
 /** カラースケール計算用に leaf の損益率を平らな配列で取り出す */
@@ -146,31 +148,9 @@ interface CellRenderProps {
 function renderTreemapCell(props: CellRenderProps, scale: ColorScale, onLeafClick: (symbol: string) => void) {
   const { x = 0, y = 0, width = 0, height = 0, depth = 0, name, plPercentage, symbol } = props
   const isLeaf = depth >= 2 && !!symbol
-  const fill = isLeaf ? getColorForValue(plPercentage ?? null, scale) : "transparent"
-  const showLabel = width > 60 && height > 24
 
-  if (isLeaf && symbol) {
+  if (!isLeaf) {
     return (
-      <g
-        role="button"
-        tabIndex={0}
-        style={{ cursor: "pointer" }}
-        onClick={() => onLeafClick(symbol)}
-        onKeyDown={(e: React.KeyboardEvent<SVGGElement>) => {
-          if (e.key === "Enter" || e.key === " ") onLeafClick(symbol)
-        }}
-      >
-        <rect x={x} y={y} width={width} height={height} fill={fill} stroke="#ffffff" strokeWidth={1} />
-        {showLabel && (
-          <text x={x + 4} y={y + 14} fill="#111827" fontSize={11} fontWeight={500}>
-            {name}
-          </text>
-        )}
-      </g>
-    )
-  }
-  return (
-    <g>
       <rect
         x={x}
         y={y}
@@ -180,6 +160,27 @@ function renderTreemapCell(props: CellRenderProps, scale: ColorScale, onLeafClic
         stroke={depth === 1 ? "#1f2937" : "#ffffff"}
         strokeWidth={depth === 1 ? 2 : 1}
       />
+    )
+  }
+
+  const fill = getColorForValue(plPercentage ?? null, scale)
+  const showLabel = width > 60 && height > 24
+  return (
+    <g
+      role="button"
+      tabIndex={0}
+      style={{ cursor: "pointer" }}
+      onClick={() => onLeafClick(symbol)}
+      onKeyDown={(e: React.KeyboardEvent<SVGGElement>) => {
+        if (e.key === "Enter" || e.key === " ") onLeafClick(symbol)
+      }}
+    >
+      <rect x={x} y={y} width={width} height={height} fill={fill} stroke="#ffffff" strokeWidth={1} />
+      {showLabel && (
+        <text x={x + 4} y={y + 14} fill="#111827" fontSize={11} fontWeight={500}>
+          {name}
+        </text>
+      )}
     </g>
   )
 }
@@ -189,7 +190,7 @@ interface TooltipPayload {
     name?: string
     value?: number
     stockName?: string
-    country?: string
+    country?: Country
     sectorName?: string
     plPercentage?: number | null
     symbol?: string
@@ -204,7 +205,7 @@ function TreemapTooltip({ active, payload }: { active?: boolean; payload?: Toolt
     <div className="rounded border border-border bg-background/95 px-3 py-2 text-sm shadow">
       <div className="font-semibold">{data.stockName || data.name}</div>
       <div className="text-xs text-muted-foreground">
-        {COUNTRY_LABELS[data.country ?? ""] ?? data.country} / {data.sectorName}
+        {data.country ? COUNTRY_LABELS[data.country] : ""} / {data.sectorName}
       </div>
       <div className="mt-1">評価額: {formatCurrency(data.value ?? 0)}</div>
       <div>損益率: {formatPercent(data.plPercentage ?? null)}</div>
@@ -222,10 +223,7 @@ export function SectorTreemap({ data, isLoading }: SectorTreemapProps) {
     [data, countryFilter, securityTypeFilter]
   )
 
-  const colorScale = useMemo(
-    () => computeColorScale(flattenColorValues(treemapData), "pl_percentage"),
-    [treemapData]
-  )
+  const colorScale = useMemo(() => computeColorScale(flattenColorValues(treemapData)), [treemapData])
 
   const handleLeafClick = (symbol: string) => {
     navigate(`/holdings/${encodeURIComponent(symbol)}`)
@@ -287,14 +285,14 @@ export function SectorTreemap({ data, isLoading }: SectorTreemapProps) {
             <div className="h-96">
               <ResponsiveContainer width="100%" height="100%">
                 <Treemap
-                  data={treemapData}
+                  data={treemapData as unknown as ReadonlyArray<{ [key: string]: unknown }>}
                   dataKey="value"
                   nameKey="name"
                   aspectRatio={4 / 3}
                   isAnimationActive={false}
                   content={
                     ((props: CellRenderProps) =>
-                      renderTreemapCell(props, colorScale, handleLeafClick)) as never
+                      renderTreemapCell(props, colorScale, handleLeafClick)) as unknown as React.ReactElement
                   }
                 >
                   <Tooltip content={<TreemapTooltip />} />

--- a/src/web/src/components/dashboard/sector-treemap.tsx
+++ b/src/web/src/components/dashboard/sector-treemap.tsx
@@ -1,0 +1,347 @@
+import { useMemo, useState } from "react"
+import { useNavigate } from "react-router"
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { Holding } from "@/lib/api/types"
+import { type ColorScale, computeColorScale, getColorForValue } from "@/lib/color-scale"
+import { formatCurrency, formatPercent } from "@/lib/format"
+
+type CountryFilter = "ALL" | "JP" | "US" | "OTHER"
+type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
+
+interface SectorTreemapProps {
+  data: Holding[] | undefined
+  isLoading: boolean
+}
+
+interface TreemapLeaf {
+  name: string
+  value: number
+  symbol: string
+  stockName: string
+  country: string
+  sectorName: string
+  plPercentage: number | null
+  [key: string]: unknown
+}
+
+interface TreemapSector {
+  name: string
+  children: TreemapLeaf[]
+  [key: string]: unknown
+}
+
+interface TreemapCountry {
+  name: string
+  children: TreemapSector[]
+  [key: string]: unknown
+}
+
+const COUNTRY_FILTERS: { value: CountryFilter; label: string }[] = [
+  { value: "ALL", label: "すべて" },
+  { value: "JP", label: "日本" },
+  { value: "US", label: "米国" },
+  { value: "OTHER", label: "その他" },
+]
+
+const SECURITY_TYPE_FILTERS: { value: SecurityTypeFilter; label: string }[] = [
+  { value: "ALL", label: "すべて" },
+  { value: "STOCK", label: "株式" },
+  { value: "ETF", label: "ETF" },
+  { value: "FUND", label: "投信" },
+  { value: "REIT", label: "REIT" },
+]
+
+const COUNTRY_LABELS: Record<string, string> = {
+  JP: "日本",
+  US: "米国",
+  OTHER: "その他",
+}
+
+/**
+ * 保有銘柄を国 → セクター → 銘柄の3階層ツリーマップ用データに変換する。
+ * 評価額（market_value）が 0 以下の銘柄、フィルタ条件に合わない銘柄は除外。
+ * country/sector_name が null のものは "OTHER"/"その他" に集約する。
+ */
+export function transformHoldingsToTreemap(
+  holdings: Holding[] | undefined,
+  filters: { country: CountryFilter; securityType: SecurityTypeFilter }
+): TreemapCountry[] {
+  if (!holdings || holdings.length === 0) return []
+
+  const filtered = holdings.filter((h) => {
+    if ((h.market_value ?? 0) <= 0) return false
+    const countryKey = h.country ?? "OTHER"
+    if (filters.country !== "ALL" && countryKey !== filters.country) return false
+    if (filters.securityType !== "ALL" && h.security_type !== filters.securityType) return false
+    return true
+  })
+
+  const byCountry = new Map<string, Map<string, TreemapLeaf[]>>()
+  for (const h of filtered) {
+    const countryKey = h.country ?? "OTHER"
+    const sectorKey = h.sector_name ?? "その他"
+    if (!byCountry.has(countryKey)) byCountry.set(countryKey, new Map())
+    const sectors = byCountry.get(countryKey)
+    if (!sectors) continue
+    if (!sectors.has(sectorKey)) sectors.set(sectorKey, [])
+    const leaves = sectors.get(sectorKey)
+    if (!leaves) continue
+    leaves.push({
+      name: h.stock_name || h.symbol,
+      value: h.market_value ?? 0,
+      symbol: h.symbol,
+      stockName: h.stock_name || h.symbol,
+      country: countryKey,
+      sectorName: sectorKey,
+      plPercentage: h.unrealized_pl_percentage,
+    })
+  }
+
+  const result: TreemapCountry[] = []
+  for (const [countryKey, sectors] of byCountry.entries()) {
+    const sectorBranches: TreemapSector[] = []
+    for (const [sectorName, leaves] of sectors.entries()) {
+      leaves.sort((a, b) => b.value - a.value)
+      sectorBranches.push({ name: sectorName, children: leaves })
+    }
+    sectorBranches.sort((a, b) => sumLeafValues(b.children) - sumLeafValues(a.children))
+    result.push({ name: COUNTRY_LABELS[countryKey] ?? countryKey, children: sectorBranches })
+  }
+  const countryTotal = (c: TreemapCountry) =>
+    c.children.reduce((s, sec) => s + sumLeafValues(sec.children), 0)
+  result.sort((a, b) => countryTotal(b) - countryTotal(a))
+  return result
+}
+
+function sumLeafValues(leaves: TreemapLeaf[]): number {
+  return leaves.reduce((sum, l) => sum + l.value, 0)
+}
+
+/** カラースケール計算用に leaf の損益率を平らな配列で取り出す */
+export function flattenColorValues(data: TreemapCountry[]): Array<number | null> {
+  const out: Array<number | null> = []
+  for (const country of data) {
+    for (const sector of country.children) {
+      for (const leaf of sector.children) {
+        out.push(leaf.plPercentage)
+      }
+    }
+  }
+  return out
+}
+
+interface CellRenderProps {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  depth?: number
+  name?: string
+  plPercentage?: number | null
+  symbol?: string
+}
+
+function renderTreemapCell(props: CellRenderProps, scale: ColorScale, onLeafClick: (symbol: string) => void) {
+  const { x = 0, y = 0, width = 0, height = 0, depth = 0, name, plPercentage, symbol } = props
+  const isLeaf = depth >= 2 && !!symbol
+  const fill = isLeaf ? getColorForValue(plPercentage ?? null, scale) : "transparent"
+  const showLabel = width > 60 && height > 24
+
+  if (isLeaf && symbol) {
+    return (
+      <g
+        role="button"
+        tabIndex={0}
+        style={{ cursor: "pointer" }}
+        onClick={() => onLeafClick(symbol)}
+        onKeyDown={(e: React.KeyboardEvent<SVGGElement>) => {
+          if (e.key === "Enter" || e.key === " ") onLeafClick(symbol)
+        }}
+      >
+        <rect x={x} y={y} width={width} height={height} fill={fill} stroke="#ffffff" strokeWidth={1} />
+        {showLabel && (
+          <text x={x + 4} y={y + 14} fill="#111827" fontSize={11} fontWeight={500}>
+            {name}
+          </text>
+        )}
+      </g>
+    )
+  }
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill="transparent"
+        stroke={depth === 1 ? "#1f2937" : "#ffffff"}
+        strokeWidth={depth === 1 ? 2 : 1}
+      />
+    </g>
+  )
+}
+
+interface TooltipPayload {
+  payload?: {
+    name?: string
+    value?: number
+    stockName?: string
+    country?: string
+    sectorName?: string
+    plPercentage?: number | null
+    symbol?: string
+  }
+}
+
+function TreemapTooltip({ active, payload }: { active?: boolean; payload?: TooltipPayload[] }) {
+  if (!active || !payload?.length) return null
+  const data = payload[0].payload
+  if (!data?.symbol) return null
+  return (
+    <div className="rounded border border-border bg-background/95 px-3 py-2 text-sm shadow">
+      <div className="font-semibold">{data.stockName || data.name}</div>
+      <div className="text-xs text-muted-foreground">
+        {COUNTRY_LABELS[data.country ?? ""] ?? data.country} / {data.sectorName}
+      </div>
+      <div className="mt-1">評価額: {formatCurrency(data.value ?? 0)}</div>
+      <div>損益率: {formatPercent(data.plPercentage ?? null)}</div>
+    </div>
+  )
+}
+
+export function SectorTreemap({ data, isLoading }: SectorTreemapProps) {
+  const navigate = useNavigate()
+  const [countryFilter, setCountryFilter] = useState<CountryFilter>("ALL")
+  const [securityTypeFilter, setSecurityTypeFilter] = useState<SecurityTypeFilter>("ALL")
+
+  const treemapData = useMemo(
+    () => transformHoldingsToTreemap(data, { country: countryFilter, securityType: securityTypeFilter }),
+    [data, countryFilter, securityTypeFilter]
+  )
+
+  const colorScale = useMemo(
+    () => computeColorScale(flattenColorValues(treemapData), "pl_percentage"),
+    [treemapData]
+  )
+
+  const handleLeafClick = (symbol: string) => {
+    navigate(`/holdings/${encodeURIComponent(symbol)}`)
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>セクター別ツリーマップ</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-96 animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>セクター別ツリーマップ</CardTitle>
+        <div className="mt-3 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">国:</span>
+            {COUNTRY_FILTERS.map((opt) => (
+              <Button
+                key={opt.value}
+                variant={countryFilter === opt.value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setCountryFilter(opt.value)}
+              >
+                {opt.label}
+              </Button>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">種別:</span>
+            {SECURITY_TYPE_FILTERS.map((opt) => (
+              <Button
+                key={opt.value}
+                variant={securityTypeFilter === opt.value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setSecurityTypeFilter(opt.value)}
+              >
+                {opt.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {treemapData.length === 0 ? (
+          <div className="flex h-96 items-center justify-center text-muted-foreground">
+            データがありません
+          </div>
+        ) : (
+          <>
+            <div className="h-96">
+              <ResponsiveContainer width="100%" height="100%">
+                <Treemap
+                  data={treemapData}
+                  dataKey="value"
+                  nameKey="name"
+                  aspectRatio={4 / 3}
+                  isAnimationActive={false}
+                  content={
+                    ((props: CellRenderProps) =>
+                      renderTreemapCell(props, colorScale, handleLeafClick)) as never
+                  }
+                >
+                  <Tooltip content={<TreemapTooltip />} />
+                </Treemap>
+              </ResponsiveContainer>
+            </div>
+            <ColorLegend scale={colorScale} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ColorLegend({ scale }: { scale: ColorScale }) {
+  const stops = useMemo(() => {
+    const samples: number[] = []
+    const steps = 7
+    for (let i = 0; i <= steps; i++) {
+      const ratio = i / steps
+      samples.push(scale.minValue + (scale.maxValue - scale.minValue) * ratio)
+    }
+    return samples
+  }, [scale])
+
+  return (
+    <div className="mt-3 flex flex-col gap-1 text-xs text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <span>損益率</span>
+        <div className="flex h-3 flex-1 overflow-hidden rounded">
+          {stops.map((v) => (
+            <div
+              key={`stop-${v.toFixed(2)}`}
+              className="flex-1"
+              style={{ backgroundColor: getColorForValue(v, scale) }}
+            />
+          ))}
+        </div>
+        <span className="tabular-nums">
+          {formatPercent(scale.minValue)} 〜 {formatPercent(scale.maxValue)}
+        </span>
+      </div>
+      {(scale.outOfRangeAbove > 0 || scale.outOfRangeBelow > 0) && (
+        <div>
+          範囲外: 上限超過 {scale.outOfRangeAbove}銘柄 / 下限超過 {scale.outOfRangeBelow}銘柄
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/web/src/components/dashboard/sector-treemap.tsx
+++ b/src/web/src/components/dashboard/sector-treemap.tsx
@@ -6,10 +6,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Holding } from "@/lib/api/types"
 import { type ColorScale, computeColorScale, getColorForValue } from "@/lib/color-scale"
 import { formatCurrency, formatPercent } from "@/lib/format"
+import { SECURITY_TYPE_FILTERS, type SecurityTypeFilter } from "@/lib/security-type"
 
 type Country = "JP" | "US" | "OTHER"
 type CountryFilter = "ALL" | Country
-type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
 
 interface SectorTreemapProps {
   data: Holding[] | undefined
@@ -49,14 +49,6 @@ const COUNTRY_FILTERS: { value: CountryFilter; label: string }[] = [
   { value: "JP", label: COUNTRY_LABELS.JP },
   { value: "US", label: COUNTRY_LABELS.US },
   { value: "OTHER", label: COUNTRY_LABELS.OTHER },
-]
-
-const SECURITY_TYPE_FILTERS: { value: SecurityTypeFilter; label: string }[] = [
-  { value: "ALL", label: "すべて" },
-  { value: "STOCK", label: "株式" },
-  { value: "ETF", label: "ETF" },
-  { value: "FUND", label: "投信" },
-  { value: "REIT", label: "REIT" },
 ]
 
 function normalizeCountry(c: Holding["country"]): Country {
@@ -247,32 +239,18 @@ export function SectorTreemap({ data, isLoading }: SectorTreemapProps) {
       <CardHeader>
         <CardTitle>セクター別ツリーマップ</CardTitle>
         <div className="mt-3 space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-muted-foreground">国:</span>
-            {COUNTRY_FILTERS.map((opt) => (
-              <Button
-                key={opt.value}
-                variant={countryFilter === opt.value ? "default" : "outline"}
-                size="sm"
-                onClick={() => setCountryFilter(opt.value)}
-              >
-                {opt.label}
-              </Button>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-muted-foreground">種別:</span>
-            {SECURITY_TYPE_FILTERS.map((opt) => (
-              <Button
-                key={opt.value}
-                variant={securityTypeFilter === opt.value ? "default" : "outline"}
-                size="sm"
-                onClick={() => setSecurityTypeFilter(opt.value)}
-              >
-                {opt.label}
-              </Button>
-            ))}
-          </div>
+          <FilterRow
+            label="国:"
+            options={COUNTRY_FILTERS}
+            value={countryFilter}
+            onChange={setCountryFilter}
+          />
+          <FilterRow
+            label="種別:"
+            options={SECURITY_TYPE_FILTERS}
+            value={securityTypeFilter}
+            onChange={setSecurityTypeFilter}
+          />
         </div>
       </CardHeader>
       <CardContent>
@@ -340,6 +318,31 @@ function ColorLegend({ scale }: { scale: ColorScale }) {
           範囲外: 上限超過 {scale.outOfRangeAbove}銘柄 / 下限超過 {scale.outOfRangeBelow}銘柄
         </div>
       )}
+    </div>
+  )
+}
+
+interface FilterRowProps<T extends string> {
+  label: string
+  options: ReadonlyArray<{ value: T; label: string }>
+  value: T
+  onChange: (next: T) => void
+}
+
+function FilterRow<T extends string>({ label, options, value, onChange }: FilterRowProps<T>) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {options.map((opt) => (
+        <Button
+          key={opt.value}
+          variant={value === opt.value ? "default" : "outline"}
+          size="sm"
+          onClick={() => onChange(opt.value)}
+        >
+          {opt.label}
+        </Button>
+      ))}
     </div>
   )
 }

--- a/src/web/src/lib/api/types.ts
+++ b/src/web/src/lib/api/types.ts
@@ -57,6 +57,8 @@ export interface Holding {
   stock_name: string | null
   security_type: string | null
   currency: string | null
+  country: "JP" | "US" | "OTHER" | null
+  sector_name: string | null
   note: string | null
 }
 

--- a/src/web/src/lib/color-scale.test.ts
+++ b/src/web/src/lib/color-scale.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { computeColorScale, getColorForValue, percentile } from "./color-scale"
+
+describe("percentile", () => {
+  it("空配列では 0 を返す", () => {
+    expect(percentile([], 50)).toBe(0)
+  })
+
+  it("単一要素ではその値を返す", () => {
+    expect(percentile([42], 50)).toBe(42)
+    expect(percentile([42], 5)).toBe(42)
+  })
+
+  it("線形補間で計算する", () => {
+    // [10, 20, 30, 40, 50] の 50 パーセンタイルは中央の 30
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30)
+    // 25 パーセンタイル: rank = 1.0 -> 20
+    expect(percentile([10, 20, 30, 40, 50], 25)).toBe(20)
+  })
+
+  it("クランプして 0/100 を超えるパーセンタイルでも端を返す", () => {
+    expect(percentile([10, 20, 30], -10)).toBe(10)
+    expect(percentile([10, 20, 30], 150)).toBe(30)
+  })
+})
+
+describe("computeColorScale", () => {
+  it("空配列ではメトリクスのデフォルトレンジを返す", () => {
+    const scale = computeColorScale([], "pl_percentage")
+    expect(scale.minValue).toBe(-50)
+    expect(scale.maxValue).toBe(100)
+    expect(scale.centerValue).toBe(0)
+    expect(scale.outOfRangeAbove).toBe(0)
+    expect(scale.outOfRangeBelow).toBe(0)
+  })
+
+  it("null や NaN を除外する", () => {
+    const scale = computeColorScale([null, undefined, Number.NaN, 10], "pl_percentage")
+    // 有効値が 1 つだけ -> minValue は center - 5 で確保される
+    expect(scale.minValue).toBeLessThanOrEqual(-5)
+    expect(scale.maxValue).toBeGreaterThanOrEqual(5)
+  })
+
+  it("全プラスの相場でも赤側が縮退しない（片側 5% 以上を保証）", () => {
+    const allPositive = [5, 10, 15, 20, 25, 30, 40, 50]
+    const scale = computeColorScale(allPositive, "pl_percentage")
+    expect(scale.minValue).toBeLessThanOrEqual(-5)
+    expect(scale.maxValue).toBeGreaterThanOrEqual(5)
+  })
+
+  it("全マイナスの相場でも緑側が縮退しない", () => {
+    const allNegative = [-30, -20, -15, -10, -5, -2]
+    const scale = computeColorScale(allNegative, "pl_percentage")
+    expect(scale.minValue).toBeLessThanOrEqual(-5)
+    expect(scale.maxValue).toBeGreaterThanOrEqual(5)
+  })
+
+  it("ceil を超える外れ値はクリップしてカウントする", () => {
+    // P95 が 100% を超えてしまうほど多くの極端値を含むケース
+    const values = Array.from({ length: 20 }, (_, i) => (i < 18 ? 10 : 250))
+    const scale = computeColorScale(values, "pl_percentage")
+    expect(scale.maxValue).toBeLessThanOrEqual(100)
+    expect(scale.outOfRangeAbove).toBeGreaterThanOrEqual(2)
+  })
+
+  it("floor を下回る外れ値はクリップしてカウントする", () => {
+    const values = Array.from({ length: 20 }, (_, i) => (i < 18 ? -10 : -80))
+    const scale = computeColorScale(values, "pl_percentage")
+    expect(scale.minValue).toBeGreaterThanOrEqual(-50)
+    expect(scale.outOfRangeBelow).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe("getColorForValue", () => {
+  const scale = computeColorScale([-30, -20, -10, 0, 10, 20, 30, 50], "pl_percentage")
+
+  it("null は中立色を返す", () => {
+    expect(getColorForValue(null, scale)).toBe("#9CA3AF")
+  })
+
+  it("プラス値は緑系を返す", () => {
+    const color = getColorForValue(20, scale)
+    expect(color).toMatch(/^hsl\(142,/)
+  })
+
+  it("マイナス値は赤系を返す", () => {
+    const color = getColorForValue(-20, scale)
+    expect(color).toMatch(/^hsl\(0,/)
+  })
+
+  it("中心値ぴったりでもエラーなく色を返す", () => {
+    const color = getColorForValue(0, scale)
+    expect(color).toMatch(/^hsl\(142,/)
+  })
+
+  it("NaN は中立色を返す", () => {
+    expect(getColorForValue(Number.NaN, scale)).toBe("#9CA3AF")
+  })
+})

--- a/src/web/src/lib/color-scale.test.ts
+++ b/src/web/src/lib/color-scale.test.ts
@@ -26,7 +26,7 @@ describe("percentile", () => {
 
 describe("computeColorScale", () => {
   it("空配列ではメトリクスのデフォルトレンジを返す", () => {
-    const scale = computeColorScale([], "pl_percentage")
+    const scale = computeColorScale([])
     expect(scale.minValue).toBe(-50)
     expect(scale.maxValue).toBe(100)
     expect(scale.centerValue).toBe(0)
@@ -35,7 +35,7 @@ describe("computeColorScale", () => {
   })
 
   it("null や NaN を除外する", () => {
-    const scale = computeColorScale([null, undefined, Number.NaN, 10], "pl_percentage")
+    const scale = computeColorScale([null, undefined, Number.NaN, 10])
     // 有効値が 1 つだけ -> minValue は center - 5 で確保される
     expect(scale.minValue).toBeLessThanOrEqual(-5)
     expect(scale.maxValue).toBeGreaterThanOrEqual(5)
@@ -43,14 +43,14 @@ describe("computeColorScale", () => {
 
   it("全プラスの相場でも赤側が縮退しない（片側 5% 以上を保証）", () => {
     const allPositive = [5, 10, 15, 20, 25, 30, 40, 50]
-    const scale = computeColorScale(allPositive, "pl_percentage")
+    const scale = computeColorScale(allPositive)
     expect(scale.minValue).toBeLessThanOrEqual(-5)
     expect(scale.maxValue).toBeGreaterThanOrEqual(5)
   })
 
   it("全マイナスの相場でも緑側が縮退しない", () => {
     const allNegative = [-30, -20, -15, -10, -5, -2]
-    const scale = computeColorScale(allNegative, "pl_percentage")
+    const scale = computeColorScale(allNegative)
     expect(scale.minValue).toBeLessThanOrEqual(-5)
     expect(scale.maxValue).toBeGreaterThanOrEqual(5)
   })
@@ -58,21 +58,21 @@ describe("computeColorScale", () => {
   it("ceil を超える外れ値はクリップしてカウントする", () => {
     // P95 が 100% を超えてしまうほど多くの極端値を含むケース
     const values = Array.from({ length: 20 }, (_, i) => (i < 18 ? 10 : 250))
-    const scale = computeColorScale(values, "pl_percentage")
+    const scale = computeColorScale(values)
     expect(scale.maxValue).toBeLessThanOrEqual(100)
     expect(scale.outOfRangeAbove).toBeGreaterThanOrEqual(2)
   })
 
   it("floor を下回る外れ値はクリップしてカウントする", () => {
     const values = Array.from({ length: 20 }, (_, i) => (i < 18 ? -10 : -80))
-    const scale = computeColorScale(values, "pl_percentage")
+    const scale = computeColorScale(values)
     expect(scale.minValue).toBeGreaterThanOrEqual(-50)
     expect(scale.outOfRangeBelow).toBeGreaterThanOrEqual(2)
   })
 })
 
 describe("getColorForValue", () => {
-  const scale = computeColorScale([-30, -20, -10, 0, 10, 20, 30, 50], "pl_percentage")
+  const scale = computeColorScale([-30, -20, -10, 0, 10, 20, 30, 50])
 
   it("null は中立色を返す", () => {
     expect(getColorForValue(null, scale)).toBe("#9CA3AF")

--- a/src/web/src/lib/color-scale.ts
+++ b/src/web/src/lib/color-scale.ts
@@ -1,49 +1,30 @@
 /**
- * ツリーマップ用の動的カラースケール計算ユーティリティ。
+ * ツリーマップ用カラースケール計算。
  *
- * 値（損益率など）の分布から P5/P95 を求め、外れ値をクリップした
- * うえで 0% を中心に赤↔緑のグラデーションを作る。極端値を視覚的に
- * 黙殺せず「上限超過 N件」として呼び出し側で表示できるよう、
- * クリップ件数も返す。
- *
- * MVP では損益率（pl_percentage）のみサポート。将来的に
- * daily_change_percentage / dividend_yield を追加できるよう
- * メトリクス毎に floor/ceil/中心を選べる構造にしてある。
+ * 値（損益率）の P5/P95 でレンジを決め、0% を中心に赤↔緑のグラデーションを作る。
+ * 全プラス／全マイナス相場でも色味が出るよう、片側を最低 ±5% は確保する。
+ * 上限／下限を超えた外れ値は呼び出し側で「N件超過」として表示できるようカウントを返す。
  */
 
-type ColorMetric = "pl_percentage"
+const FLOOR = -50
+const CEIL = 100
+const CENTER = 0
+const MIN_HALF_RANGE = 5
 
-interface MetricConfig {
-  /** 赤側下限（これより下にはクリップされない） */
-  floor: number
-  /** 緑側上限（これより上にはクリップされない） */
-  ceil: number
-  /** カラースケールの中心値（通常 0） */
-  center: number
-}
-
-const METRIC_CONFIGS: Record<ColorMetric, MetricConfig> = {
-  pl_percentage: { floor: -50, ceil: 100, center: 0 },
-}
+const NEUTRAL_COLOR = "#9CA3AF"
+const POSITIVE_HUE = 142
+const NEGATIVE_HUE = 0
+const SATURATION = 65
 
 export interface ColorScale {
-  metric: ColorMetric
-  /** 赤側の最低値（負方向）。center より小さい */
   minValue: number
-  /** 緑側の最高値（正方向）。center より大きい */
   maxValue: number
-  /** 中心値 */
   centerValue: number
-  /** クリップされた件数（上限を超えた銘柄数） */
   outOfRangeAbove: number
-  /** クリップされた件数（下限を割った銘柄数） */
   outOfRangeBelow: number
 }
 
-/**
- * 昇順ソート済み配列からパーセンタイル値を線形補間で計算する。
- * 空配列のときは 0 を返す。
- */
+/** 昇順ソート済み配列からパーセンタイル値を線形補間で計算する */
 export function percentile(sortedAsc: number[], p: number): number {
   if (sortedAsc.length === 0) return 0
   if (sortedAsc.length === 1) return sortedAsc[0]
@@ -56,25 +37,40 @@ export function percentile(sortedAsc: number[], p: number): number {
   return sortedAsc[lower] + (sortedAsc[upper] - sortedAsc[lower]) * fraction
 }
 
-/**
- * 値配列からカラースケールを計算する。
- *
- * - P5/P95 でレンジを決め、floor/ceil 内に収まるようクリップ
- * - 全プラスの相場でも minValue が center まで縮退しないよう、
- *   片側を必ず一定幅以上確保する（最低 5% を保証）
- */
-export function computeColorScale(values: Array<number | null | undefined>, metric: ColorMetric): ColorScale {
-  const config = METRIC_CONFIGS[metric]
+/** 昇順ソート済み配列で threshold より大きい最初のインデックスを返す（無ければ length） */
+function firstIndexAbove(sortedAsc: number[], threshold: number): number {
+  let lo = 0
+  let hi = sortedAsc.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (sortedAsc[mid] > threshold) hi = mid
+    else lo = mid + 1
+  }
+  return lo
+}
+
+/** 昇順ソート済み配列で threshold より小さい最後のインデックス+1 を返す */
+function countBelow(sortedAsc: number[], threshold: number): number {
+  let lo = 0
+  let hi = sortedAsc.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (sortedAsc[mid] < threshold) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+export function computeColorScale(values: Array<number | null | undefined>): ColorScale {
   const validValues = values
     .filter((v): v is number => typeof v === "number" && Number.isFinite(v))
     .sort((a, b) => a - b)
 
   if (validValues.length === 0) {
     return {
-      metric,
-      minValue: config.floor,
-      maxValue: config.ceil,
-      centerValue: config.center,
+      minValue: FLOOR,
+      maxValue: CEIL,
+      centerValue: CENTER,
       outOfRangeAbove: 0,
       outOfRangeBelow: 0,
     }
@@ -82,49 +78,28 @@ export function computeColorScale(values: Array<number | null | undefined>, metr
 
   const rawMin = percentile(validValues, 5)
   const rawMax = percentile(validValues, 95)
-  // 最低レンジ幅（片側 5%）を保証して、全プラス/全マイナスでも色味が出るようにする
-  const MIN_HALF_RANGE = 5
-  const minValue = Math.max(config.floor, Math.min(rawMin, config.center - MIN_HALF_RANGE))
-  const maxValue = Math.min(config.ceil, Math.max(rawMax, config.center + MIN_HALF_RANGE))
-
-  const outOfRangeAbove = validValues.filter((v) => v > maxValue).length
-  const outOfRangeBelow = validValues.filter((v) => v < minValue).length
+  const minValue = Math.max(FLOOR, Math.min(rawMin, CENTER - MIN_HALF_RANGE))
+  const maxValue = Math.min(CEIL, Math.max(rawMax, CENTER + MIN_HALF_RANGE))
 
   return {
-    metric,
     minValue,
     maxValue,
-    centerValue: config.center,
-    outOfRangeAbove,
-    outOfRangeBelow,
+    centerValue: CENTER,
+    outOfRangeAbove: validValues.length - firstIndexAbove(validValues, maxValue),
+    outOfRangeBelow: countBelow(validValues, minValue),
   }
 }
 
-const NEUTRAL_COLOR = "#9CA3AF"
-const POSITIVE_HUE = 142
-const NEGATIVE_HUE = 0
-const SATURATION = 65
-
-/**
- * 値からカラーを取得する。中心値から離れるほど濃く、HSL で輝度を変化させる。
- * null/NaN は中立色を返す。
- */
 export function getColorForValue(value: number | null | undefined, scale: ColorScale): string {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return NEUTRAL_COLOR
   }
-
-  if (value >= scale.centerValue) {
-    const range = scale.maxValue - scale.centerValue
-    if (range <= 0) return NEUTRAL_COLOR
-    const ratio = Math.max(0, Math.min(1, (value - scale.centerValue) / range))
-    const lightness = 85 - ratio * 40
-    return `hsl(${POSITIVE_HUE}, ${SATURATION}%, ${lightness}%)`
-  }
-
-  const range = scale.centerValue - scale.minValue
+  const isPositive = value >= scale.centerValue
+  const hue = isPositive ? POSITIVE_HUE : NEGATIVE_HUE
+  const range = isPositive ? scale.maxValue - scale.centerValue : scale.centerValue - scale.minValue
   if (range <= 0) return NEUTRAL_COLOR
-  const ratio = Math.max(0, Math.min(1, (scale.centerValue - value) / range))
+  const distance = isPositive ? value - scale.centerValue : scale.centerValue - value
+  const ratio = Math.max(0, Math.min(1, distance / range))
   const lightness = 85 - ratio * 40
-  return `hsl(${NEGATIVE_HUE}, ${SATURATION}%, ${lightness}%)`
+  return `hsl(${hue}, ${SATURATION}%, ${lightness}%)`
 }

--- a/src/web/src/lib/color-scale.ts
+++ b/src/web/src/lib/color-scale.ts
@@ -1,0 +1,130 @@
+/**
+ * ツリーマップ用の動的カラースケール計算ユーティリティ。
+ *
+ * 値（損益率など）の分布から P5/P95 を求め、外れ値をクリップした
+ * うえで 0% を中心に赤↔緑のグラデーションを作る。極端値を視覚的に
+ * 黙殺せず「上限超過 N件」として呼び出し側で表示できるよう、
+ * クリップ件数も返す。
+ *
+ * MVP では損益率（pl_percentage）のみサポート。将来的に
+ * daily_change_percentage / dividend_yield を追加できるよう
+ * メトリクス毎に floor/ceil/中心を選べる構造にしてある。
+ */
+
+type ColorMetric = "pl_percentage"
+
+interface MetricConfig {
+  /** 赤側下限（これより下にはクリップされない） */
+  floor: number
+  /** 緑側上限（これより上にはクリップされない） */
+  ceil: number
+  /** カラースケールの中心値（通常 0） */
+  center: number
+}
+
+const METRIC_CONFIGS: Record<ColorMetric, MetricConfig> = {
+  pl_percentage: { floor: -50, ceil: 100, center: 0 },
+}
+
+export interface ColorScale {
+  metric: ColorMetric
+  /** 赤側の最低値（負方向）。center より小さい */
+  minValue: number
+  /** 緑側の最高値（正方向）。center より大きい */
+  maxValue: number
+  /** 中心値 */
+  centerValue: number
+  /** クリップされた件数（上限を超えた銘柄数） */
+  outOfRangeAbove: number
+  /** クリップされた件数（下限を割った銘柄数） */
+  outOfRangeBelow: number
+}
+
+/**
+ * 昇順ソート済み配列からパーセンタイル値を線形補間で計算する。
+ * 空配列のときは 0 を返す。
+ */
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0
+  if (sortedAsc.length === 1) return sortedAsc[0]
+  const clampedP = Math.max(0, Math.min(100, p))
+  const rank = (clampedP / 100) * (sortedAsc.length - 1)
+  const lower = Math.floor(rank)
+  const upper = Math.ceil(rank)
+  if (lower === upper) return sortedAsc[lower]
+  const fraction = rank - lower
+  return sortedAsc[lower] + (sortedAsc[upper] - sortedAsc[lower]) * fraction
+}
+
+/**
+ * 値配列からカラースケールを計算する。
+ *
+ * - P5/P95 でレンジを決め、floor/ceil 内に収まるようクリップ
+ * - 全プラスの相場でも minValue が center まで縮退しないよう、
+ *   片側を必ず一定幅以上確保する（最低 5% を保証）
+ */
+export function computeColorScale(values: Array<number | null | undefined>, metric: ColorMetric): ColorScale {
+  const config = METRIC_CONFIGS[metric]
+  const validValues = values
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v))
+    .sort((a, b) => a - b)
+
+  if (validValues.length === 0) {
+    return {
+      metric,
+      minValue: config.floor,
+      maxValue: config.ceil,
+      centerValue: config.center,
+      outOfRangeAbove: 0,
+      outOfRangeBelow: 0,
+    }
+  }
+
+  const rawMin = percentile(validValues, 5)
+  const rawMax = percentile(validValues, 95)
+  // 最低レンジ幅（片側 5%）を保証して、全プラス/全マイナスでも色味が出るようにする
+  const MIN_HALF_RANGE = 5
+  const minValue = Math.max(config.floor, Math.min(rawMin, config.center - MIN_HALF_RANGE))
+  const maxValue = Math.min(config.ceil, Math.max(rawMax, config.center + MIN_HALF_RANGE))
+
+  const outOfRangeAbove = validValues.filter((v) => v > maxValue).length
+  const outOfRangeBelow = validValues.filter((v) => v < minValue).length
+
+  return {
+    metric,
+    minValue,
+    maxValue,
+    centerValue: config.center,
+    outOfRangeAbove,
+    outOfRangeBelow,
+  }
+}
+
+const NEUTRAL_COLOR = "#9CA3AF"
+const POSITIVE_HUE = 142
+const NEGATIVE_HUE = 0
+const SATURATION = 65
+
+/**
+ * 値からカラーを取得する。中心値から離れるほど濃く、HSL で輝度を変化させる。
+ * null/NaN は中立色を返す。
+ */
+export function getColorForValue(value: number | null | undefined, scale: ColorScale): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return NEUTRAL_COLOR
+  }
+
+  if (value >= scale.centerValue) {
+    const range = scale.maxValue - scale.centerValue
+    if (range <= 0) return NEUTRAL_COLOR
+    const ratio = Math.max(0, Math.min(1, (value - scale.centerValue) / range))
+    const lightness = 85 - ratio * 40
+    return `hsl(${POSITIVE_HUE}, ${SATURATION}%, ${lightness}%)`
+  }
+
+  const range = scale.centerValue - scale.minValue
+  if (range <= 0) return NEUTRAL_COLOR
+  const ratio = Math.max(0, Math.min(1, (scale.centerValue - value) / range))
+  const lightness = 85 - ratio * 40
+  return `hsl(${NEGATIVE_HUE}, ${SATURATION}%, ${lightness}%)`
+}

--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -22,6 +22,8 @@ const baseHolding: Holding = {
   stock_name: "トヨタ自動車",
   security_type: "stock",
   currency: "JPY",
+  country: null,
+  sector_name: null,
   note: null,
 }
 

--- a/src/web/src/lib/csv.test.ts
+++ b/src/web/src/lib/csv.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest"
-import type { Holding } from "./api/types"
+import type { Holding } from "@/lib/api/types"
+import { createHolding } from "@/test/factories"
 import { escapeCsvField, holdingsToCsv } from "./csv"
 
 const BOM = "﻿"
 
-const baseHolding: Holding = {
+const baseHolding: Holding = createHolding({
   symbol: "7203",
   quantity: 100,
   average_cost: 2000,
@@ -17,15 +18,10 @@ const baseHolding: Holding = {
   unrealized_pl_percentage: 25,
   total_pl: 51500,
   total_pl_percentage: 25.75,
-  user_id: 1,
   last_updated: "2026-05-01T10:00:00+09:00",
   stock_name: "トヨタ自動車",
   security_type: "stock",
-  currency: "JPY",
-  country: null,
-  sector_name: null,
-  note: null,
-}
+})
 
 describe("escapeCsvField", () => {
   it("通常の文字列はそのまま返す", () => {

--- a/src/web/src/lib/security-type.ts
+++ b/src/web/src/lib/security-type.ts
@@ -1,0 +1,9 @@
+export type SecurityTypeFilter = "ALL" | "STOCK" | "ETF" | "FUND" | "REIT"
+
+export const SECURITY_TYPE_FILTERS: { value: SecurityTypeFilter; label: string }[] = [
+  { value: "ALL", label: "すべて" },
+  { value: "STOCK", label: "株式" },
+  { value: "ETF", label: "ETF" },
+  { value: "FUND", label: "投信" },
+  { value: "REIT", label: "REIT" },
+]

--- a/src/web/src/test/factories.ts
+++ b/src/web/src/test/factories.ts
@@ -1,0 +1,31 @@
+import type { Holding } from "@/lib/api/types"
+
+/**
+ * テスト用 Holding 生成ヘルパ。
+ * 必要なフィールドだけ overrides で上書きする。
+ */
+export function createHolding(overrides: Partial<Holding> = {}): Holding {
+  return {
+    symbol: "TEST",
+    quantity: 100,
+    average_cost: 1000,
+    total_cost: 100000,
+    current_price: 1100,
+    market_value: 110000,
+    realized_pl: 0,
+    total_dividend: 0,
+    unrealized_pl: 10000,
+    unrealized_pl_percentage: 10,
+    total_pl: 10000,
+    total_pl_percentage: 10,
+    user_id: 1,
+    last_updated: "2024-01-01",
+    stock_name: "テスト",
+    security_type: "STOCK",
+    currency: "JPY",
+    country: null,
+    sector_name: null,
+    note: null,
+    ...overrides,
+  }
+}


### PR DESCRIPTION
## 概要

ダッシュボードに保有銘柄をセクター別に可視化するツリーマップコンポーネントを追加しました。国・証券種別でフィルタリング可能で、損益率に応じた色分け表示に対応しています。

## 主な変更

### フロントエンド

- **新規コンポーネント**: `src/web/src/components/dashboard/sector-treemap.tsx`
  - 国 → セクター → 銘柄の3階層ツリーマップ構造
  - 国フィルタ（日本/米国/その他）と証券種別フィルタ（株式/ETF/投信/REIT）
  - 損益率に応じた赤↔緑のグラデーション色分け
  - 銘柄クリックで詳細ページへ遷移
  - カラーレジェンド表示

- **新規ユーティリティ**: `src/web/src/lib/color-scale.ts`
  - 損益率のP5/P95でレンジを決定
  - 0%を中心に赤↔緑のHSLグラデーション生成
  - 全プラス/全マイナス相場でも色味が出るよう片側5%以上を確保
  - 外れ値のカウント機能

- **テスト**: `src/web/src/components/dashboard/sector-treemap.test.tsx` と `src/web/src/lib/color-scale.test.ts`
  - データ変換ロジックの正常系テスト
  - フィルタリング動作確認
  - カラースケール計算の検証

- **ダッシュボード統合**: `src/web/src/components/dashboard/dashboard.tsx`
  - `SectorTreemap`コンポーネントを追加
  - 保有銘柄データを取得して表示

### バックエンド

- **API拡張**: `src/api/stock/services/holding_service.py`
  - `_derive_country_and_sector()` 関数を追加
  - 保有銘柄に国情報（JP/US/OTHER）とセクター名を付与
  - JPY建て→JP、USD建て→US、投信→OTHER に分類
  - JPX詳細レコードから17業種、US詳細レコードからGICSセクターを取得

- **スキーマ更新**: `src/api/stock/schemas.py`
  - `Holding`スキーマに`country`と`sector_name`フィールドを追加

- **型定義更新**: `src/web/src/lib/api/types.ts`
  - `Holding`インターフェースに`country`と`sector_name`を追加

- **テスト追加**: `src/api/tests/api/test_holdings.py`
  - 日本株のセクター名取得テスト
  - 米国株の国・セクター取得テスト

## 実装の特徴

- **3階層構造**: 国 → セクター → 銘柄で階層的に可視化
- **フィルタリング**: 国と証券種別で動的にデータを絞り込み
- **色分け表示**: 損益率をHSLグラデーションで表現（赤=マイナス、緑=プラス）
- **外れ値対応**: P5/P95でレンジを決定し、外れ値をカウント表示
-

https://claude.ai/code/session_01Vs2rRE7VptUh4zm1XwTCRz