### PR TITLE
chore: add Socket Firewall to dependency installs

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -26,10 +26,15 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install ruff==0.9.1
+          sfw pip install --upgrade pip
+          sfw pip install ruff==0.9.1
 
       - name: Run Ruff Check
         working-directory: src/api

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -18,24 +18,31 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: node:20-bookworm
     timeout-minutes: 30
     env:
       JQUANTS_API_KEY: ${{ secrets.JQUANTS_API_KEY }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv and Python
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
         id: setup-uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.9.21"
-          python-version: "3.13"
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
 
       - name: Sync dependencies
         working-directory: src/api
-        run: uv sync --frozen
+        run: sfw uv sync --frozen
 
       - name: Run pytest (parallel)
         working-directory: src/api

--- a/.github/workflows/biome-autofix.yml
+++ b/.github/workflows/biome-autofix.yml
@@ -29,9 +29,14 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "src/web/pnpm-lock.yaml"
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
+
       - name: Install dependencies
         working-directory: src/web
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Run Biome lint with fix
         working-directory: src/web

--- a/.github/workflows/ruff-autofix.yml
+++ b/.github/workflows/ruff-autofix.yml
@@ -27,10 +27,15 @@ jobs:
         with:
           version: "0.5.13"
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
+
       - name: Install dependencies for api
         run: |
           cd src/api
-          uv sync
+          sfw uv sync
 
       - name: Run Ruff check with fix
         run: |

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -33,9 +33,14 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "src/web/pnpm-lock.yaml"
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@937f824ec476dfd164d4a4d9995751427b0be143 # v1
+        with:
+          mode: firewall
+
       - name: Install dependencies
         working-directory: src/web
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
 
       - name: Run Biome CI (lint + format)
         working-directory: src/web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ React + Vite ベースのSPAです。Vercelでデプロイされています。
 
 1. 実装計画を立てる。セッション内ですでにプランニングが終わっている場合は不要
 2. コードを実装する
-3. `pnpm install` で依存関係を更新する
+3. `sfw pnpm install` でSocket Firewallを通して依存関係を更新する
 4. テストコードを実装する（`src/web/docs/testing-guide.md`を参照）
 5. `pnpm check` を実行し、lint/format/typecheck/knipが通ることを確認する
 6. `pnpm test`でテストを実行する
@@ -125,6 +125,9 @@ React + Vite ベースのSPAです。Vercelでデプロイされています。
 # 開発サーバーの起動
 pnpm dev
 
+# 依存関係のインストール（Socket Firewall経由）
+sfw pnpm install
+
 # ビルド
 pnpm build
 
@@ -146,7 +149,7 @@ FastAPIベースのREST APIです。PostgreSQLをデータベースとして使�
 
 1. 実装計画を立てる。セッション内ですでにプランニングが終わっている場合は不要
 2. コードを実装する
-3. `uv sync` で依存関係をインストールし、仮想環境を有効化する
+3. `sfw uv sync` でSocket Firewallを通して依存関係をインストールし、仮想環境を有効化する
 4. テストコードを実装する（`src/api/docs/testing-guide.md`を参照）
 5. `uv run ruff format` でコードを整形する
 6. `uv run ruff check --fix` でコードスタイルを整える
@@ -165,6 +168,9 @@ FastAPIベースのREST APIです。PostgreSQLをデータベースとして使�
 ```bash
 # 開発サーバ起動
 uv run uvicorn stock.app:app --reload --port 8000
+
+# 依存関係のインストール（Socket Firewall経由）
+sfw uv sync
 
 # テスト実行（api-test-runnerサブエージェントに任せることを推奨）
 uv run pytest

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ InvestLogixは、日本株・米国株の取引/保有/配当を記録し、ポ�
 - Cloud Run Jobs のイメージ更新: main マージ後に `scripts/update-cloud-run-jobs.sh`
 - 株価データは `price_history` テーブルから読み込む。日次バッチ `recalc-holdings` が冒頭で直近2週間分を upsert する。新規環境やマイグレーション直後はテーブルが空でダッシュボードに評価額が出ないため、`gcloud run jobs execute recalc-holdings` で手動実行するか翌朝のスケジュール実行を待つ
 
+### 依存関係の防御
+サプライチェーン攻撃対策として [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free) を導入しています。依存関係を取得するときは `sfw` 経由で実行します。
+
 ## リポジトリ構成
 
 ```
@@ -91,7 +94,7 @@ docker compose exec api uv run python -m stock.jobs.update_and_notify
 
 ```bash
 cd src/web
-pnpm install
+sfw pnpm install
 cp .env.local.example .env.local
 pnpm dev
 ```
@@ -103,12 +106,12 @@ pnpm dev
 
 ### Backend（`src/api`）
 
-前提: Python（3.13+）、`uv`、DB（Docker or 別途用意）
+前提: Python（3.13+）、`uv`、`sfw`、DB（Docker or 別途用意）
 
 ```bash
 cd src/api
 cp .env.sample .env
-uv sync
+sfw uv sync
 uv run alembic upgrade head
 uv run uvicorn stock.app:app --reload --port 8000
 ```

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -7,8 +7,14 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# 依存解決にuvを利用
+# 依存解決にuvを利用し、取得時はSocket Firewallを通す
 RUN pip install --no-cache-dir uv==0.9.21
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL -o /usr/local/bin/sfw \
+        https://github.com/SocketDev/sfw-free/releases/latest/download/sfw-free-linux-x86_64 \
+    && chmod +x /usr/local/bin/sfw \
+    && rm -rf /var/lib/apt/lists/*
 
 # 依存解決に必要なファイルを先にコピーしてキャッシュ効率を上げる
 COPY pyproject.toml uv.lock README.md ./
@@ -16,7 +22,7 @@ COPY stock ./stock/
 COPY alembic ./alembic/
 
 # 本番用依存のみインストール（/app/.venv に作成され、上の PATH で `python` から参照される）
-RUN uv sync --frozen --no-dev
+RUN sfw uv sync --frozen --no-dev
 
 EXPOSE 8080
 

--- a/src/api/dockerfile.dev
+++ b/src/api/dockerfile.dev
@@ -6,8 +6,14 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /src
 
-# pipを使ってuvをインストール
+# pipを使ってuvをインストールし、取得時はSocket Firewallを通す
 RUN pip install uv==0.9.21
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL -o /usr/local/bin/sfw \
+        https://github.com/SocketDev/sfw-free/releases/latest/download/sfw-free-linux-x86_64 \
+    && chmod +x /usr/local/bin/sfw \
+    && rm -rf /var/lib/apt/lists/*
 
 # 必要なファイルのみをコピー
 COPY pyproject.toml uv.lock ./
@@ -16,7 +22,7 @@ COPY alembic ./alembic/
 COPY README.md ./
 
 # uvでライブラリをインストール
-RUN if [ -f pyproject.toml ]; then uv sync; fi
+RUN if [ -f pyproject.toml ]; then sfw uv sync; fi
 
 # uvicornのサーバーを立ち上げる
 ENTRYPOINT ["uv", "run", "uvicorn", "stock.app:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--log-level", "info"]

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -4,5 +4,11 @@ WORKDIR /app
 
 # pnpmを有効化
 RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL -o /usr/local/bin/sfw \
+        https://github.com/SocketDev/sfw-free/releases/latest/download/sfw-free-linux-x86_64 \
+    && chmod +x /usr/local/bin/sfw \
+    && rm -rf /var/lib/apt/lists/*
 
-CMD ["sh", "-c", "pnpm install && pnpm dev --host"]
+CMD ["sh", "-c", "sfw pnpm install && pnpm dev --host"]


### PR DESCRIPTION
## Summary
- Add Socket Firewall setup to dependency-installing GitHub Actions workflows
- Route pnpm, pip, and uv dependency installs through sfw
- Install sfw in API/Web Docker images and document local sfw usage

## Verification
- git diff --check
- docker build -f src/api/Dockerfile src/api -t investlogix-api:sfw-short-check
- docker build -f src/web/Dockerfile src/web -t investlogix-web:sfw-curl-check