### PR TITLE
test: trigger Socket GitHub App

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -39,7 +39,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^25",
+    "@types/node": "25.6.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -41,7 +41,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "25.6.2",
     "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "happy-dom": "^20.9.0",
     "knip": "^6.12.2",

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         specifier: ^19
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19
+        specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^25
+        specifier: 25.6.2
         version: 25.6.2
       '@types/react':
         specifier: ^19


### PR DESCRIPTION
## Purpose
This PR is only for testing the Socket GitHub App integration.

## Change
- Changes the existing `@types/node` devDependency specifier from `^25` to `25.6.2`
- Updates `src/web/pnpm-lock.yaml`

## Note
Do not merge this PR. It exists only to trigger dependency-change analysis from Socket.