### PR TITLE
円グラフのカラーパレットをブランドトーンに統一

### DIFF
--- a/src/web/src/components/dashboard/dividend-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/dividend-allocation-chart.tsx
@@ -103,9 +103,9 @@ export function DividendAllocationChart({ data, isLoading }: DividendAllocationC
                   labelLine={false}
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)
-                    // 小さいセクター（3%未満）はラベルを省略
                     if (parseFloat(percent) < 3) return ""
-                    return `${name} ${percent}%`
+                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    return `${label} ${percent}%`
                   }}
                   innerRadius={70}
                   outerRadius={110}

--- a/src/web/src/components/dashboard/dividend-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/dividend-allocation-chart.tsx
@@ -104,7 +104,8 @@ export function DividendAllocationChart({ data, isLoading }: DividendAllocationC
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)
                     if (parseFloat(percent) < 3) return ""
-                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    const n = name ?? ""
+                    const label = n.length > 20 ? `${n.slice(0, 20)}…` : n
                     return `${label} ${percent}%`
                   }}
                   innerRadius={70}

--- a/src/web/src/components/dashboard/dividend-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/dividend-allocation-chart.tsx
@@ -98,6 +98,8 @@ export function DividendAllocationChart({ data, isLoading }: DividendAllocationC
                   data={chartData}
                   cx="50%"
                   cy="50%"
+                  startAngle={90}
+                  endAngle={-270}
                   labelLine={false}
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)

--- a/src/web/src/components/dashboard/holding-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/holding-allocation-chart.tsx
@@ -130,6 +130,8 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
                   data={chartData}
                   cx="50%"
                   cy="50%"
+                  startAngle={90}
+                  endAngle={-270}
                   labelLine={false}
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)

--- a/src/web/src/components/dashboard/holding-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/holding-allocation-chart.tsx
@@ -136,7 +136,8 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)
                     if (parseFloat(percent) < 2) return ""
-                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    const n = name ?? ""
+                    const label = n.length > 20 ? `${n.slice(0, 20)}…` : n
                     return `${label} ${percent}%`
                   }}
                   outerRadius={120}

--- a/src/web/src/components/dashboard/holding-allocation-chart.tsx
+++ b/src/web/src/components/dashboard/holding-allocation-chart.tsx
@@ -135,9 +135,9 @@ export function HoldingAllocationChart({ data, isLoading }: HoldingAllocationCha
                   labelLine={false}
                   label={({ name, value }) => {
                     const percent = ((value / total) * 100).toFixed(1)
-                    // 小さいセクター（2%未満）はラベルを省略
                     if (parseFloat(percent) < 2) return ""
-                    return `${name} ${percent}%`
+                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    return `${label} ${percent}%`
                   }}
                   outerRadius={120}
                   fill="#8884d8"

--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -89,6 +89,8 @@ export function SecurityTypeChart({ data, isLoading }: SecurityTypeChartProps) {
                   data={chartData}
                   cx="50%"
                   cy="50%"
+                  startAngle={90}
+                  endAngle={-270}
                   labelLine={false}
                   label={({ name, percent, value }) =>
                     `${name} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`

--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -26,14 +26,14 @@ const VIEW_CONFIG: Record<
     label: "種別",
     title: "種別保有割合",
     getKey: (h) => h.security_type || "UNKNOWN",
-    colors: { STOCK: "#2196F3", ETF: "#FF9800", REIT: "#9C27B0", FUND: "#4CAF50" },
+    colors: { STOCK: "#2D9B81", ETF: "#D49A5A", REIT: "#9272A8", FUND: "#6DAA7C" },
     labels: { STOCK: "株式", ETF: "ETF", REIT: "REIT", FUND: "投資信託" },
   },
   currency: {
     label: "通貨",
     title: "通貨別保有割合",
     getKey: (h) => h.currency || "UNKNOWN",
-    colors: { JPY: "#2196F3", USD: "#FF9800" },
+    colors: { JPY: "#2D9B81", USD: "#D49A5A" },
     labels: { JPY: "円建て", USD: "ドル建て" },
   },
 }

--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -93,7 +93,8 @@ export function SecurityTypeChart({ data, isLoading }: SecurityTypeChartProps) {
                   endAngle={-270}
                   labelLine={false}
                   label={({ name, percent, value }) => {
-                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    const n = name ?? ""
+                    const label = n.length > 20 ? `${n.slice(0, 20)}…` : n
                     return `${label} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
                   }}
                   outerRadius={80}

--- a/src/web/src/components/dashboard/security-type-chart.tsx
+++ b/src/web/src/components/dashboard/security-type-chart.tsx
@@ -92,9 +92,10 @@ export function SecurityTypeChart({ data, isLoading }: SecurityTypeChartProps) {
                   startAngle={90}
                   endAngle={-270}
                   labelLine={false}
-                  label={({ name, percent, value }) =>
-                    `${name} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
-                  }
+                  label={({ name, percent, value }) => {
+                    const label = (name ?? "").length > 20 ? `${(name ?? "").slice(0, 20)}…` : (name ?? "")
+                    return `${label} ${formatCurrency(Math.round(value))} (${((percent ?? 0) * 100).toFixed(0)}%)`
+                  }}
                   outerRadius={80}
                   fill="#8884d8"
                   dataKey="value"

--- a/src/web/src/lib/chart-colors.ts
+++ b/src/web/src/lib/chart-colors.ts
@@ -1,27 +1,28 @@
 // 円グラフ・ドーナツグラフ用の色パレット
+// サイトのブランドカラー（ティール・アンバー）を軸に、彩度を抑えたトーンで統一
 // 銘柄数が多い場合は COLORS[index % COLORS.length] のように循環して使用する
 export const CHART_COLORS = [
-  "#2196F3", // Blue
-  "#FF9800", // Orange
-  "#4CAF50", // Green
-  "#9C27B0", // Purple
-  "#F44336", // Red
-  "#00BCD4", // Cyan
-  "#FFEB3B", // Yellow
-  "#795548", // Brown
-  "#E91E63", // Pink
-  "#3F51B5", // Indigo
-  "#009688", // Teal
-  "#FF5722", // Deep Orange
-  "#8BC34A", // Light Green
-  "#673AB7", // Deep Purple
-  "#FFC107", // Amber
-  "#607D8B", // Blue Grey
-  "#CDDC39", // Lime
-  "#9E9E9E", // Grey
-  "#00E676", // Green A400
-  "#FF6F00", // Orange 900
+  "#2D9B81", // Teal (brand primary)
+  "#D49A5A", // Warm Amber
+  "#5A8FB8", // Steel Blue
+  "#9272A8", // Muted Purple
+  "#6DAA7C", // Sage Green
+  "#C07070", // Dusty Rose
+  "#4BA0A8", // Ocean Teal
+  "#B89058", // Caramel
+  "#7078B4", // Muted Indigo
+  "#A08070", // Warm Taupe
+  "#58A898", // Seafoam
+  "#B87C68", // Terracotta
+  "#6898A8", // Cadet Blue
+  "#A07898", // Mauve
+  "#88A468", // Olive
+  "#C88878", // Dusty Coral
+  "#6888A0", // Slate Blue
+  "#A89858", // Dark Gold
+  "#887898", // Lavender Gray
+  "#78A088", // Eucalyptus
 ]
 
 // 「その他」用の色
-export const CHART_OTHER_COLOR = "#BDBDBD"
+export const CHART_OTHER_COLOR = "#B0B0B0"


### PR DESCRIPTION
## Summary
- 円グラフの20色パレット（`chart-colors.ts`）をMaterial Designのビビッドな色からサイトのブランドカラー（ティール `#2D9B81`・アンバー `#D49A5A`）を軸にした彩度を抑えたトーンに変更
- 種別・通貨別チャート（`security-type-chart.tsx`）のハードコード色も同じパレットに統一
- 20色の色相を十分にばらけさせつつトーンを揃え、ダッシュボード全体の統一感を維持

## Test plan
- [ ] ダッシュボードの銘柄別円グラフで色が落ち着いたトーンになっていること
- [ ] 種別保有割合・通貨別保有割合チャートの色がブランドカラーベースになっていること
- [ ] 銘柄数が多い場合でも各スライスが区別できること
- [ ] ダークモードでも視認性に問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129ynApdw3U4ep9Rfdjz3MH