### PR TITLE
feat(web): 配当金グラフをDividendページにも表示

### DIFF
--- a/src/web/src/routes/Dividends.tsx
+++ b/src/web/src/routes/Dividends.tsx
@@ -1,9 +1,11 @@
 import { RefreshCw } from "lucide-react"
 import useSWR from "swr"
+import { DividendAllocationChart } from "@/components/dashboard/dividend-allocation-chart"
+import { DividendChart } from "@/components/dashboard/dividend-chart"
 import { DividendsTable } from "@/components/dividends/dividends-table"
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout"
 import { Button } from "@/components/ui/button"
-import { getDividends } from "@/lib/api/client"
+import { getDividendAllocation, getDividends, getDividendsMonthly } from "@/lib/api/client"
 import { useAuthStore } from "@/lib/stores/auth-store"
 
 export default function Dividends() {
@@ -15,8 +17,24 @@ export default function Dividends() {
     mutate,
   } = useSWR(isAuthenticated ? "/api/v1/dividends/" : null, getDividends)
 
+  const {
+    data: dividendsMonthly,
+    isLoading: monthlyLoading,
+    mutate: mutateMonthly,
+  } = useSWR(isAuthenticated ? "dividends-monthly" : null, getDividendsMonthly)
+
+  const {
+    data: dividendsBySymbol,
+    isLoading: bySymbolLoading,
+    mutate: mutateBySymbol,
+  } = useSWR(isAuthenticated ? "dividends-by-symbol" : null, getDividendAllocation)
+
+  const isRefreshing = isLoading || monthlyLoading || bySymbolLoading
+
   const handleRefresh = () => {
     mutate()
+    mutateMonthly()
+    mutateBySymbol()
   }
 
   return (
@@ -24,10 +42,14 @@ export default function Dividends() {
       <div className="mx-auto max-w-7xl space-y-6 p-4 md:p-6">
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">配当金履歴</h2>
-          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isLoading}>
-            <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+          <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isRefreshing}>
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
             Refresh
           </Button>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <DividendChart data={dividendsMonthly} isLoading={monthlyLoading} />
+          <DividendAllocationChart data={dividendsBySymbol} isLoading={bySymbolLoading} />
         </div>
         <DividendsTable dividends={dividends} isLoading={isLoading} />
       </div>


### PR DESCRIPTION
## 概要

ダッシュボードにある配当金グラフ2つ（月別配当の棒グラフ・銘柄別割合のドーナツグラフ）を、Dividendページにも表示するようにしました。

## 背景

CSVアップロード完了画面から「配当金を表示」で `/dividends` に遷移できますが、これまでDividendページには配当金履歴テーブルしかなく、グラフを見るには結局ダッシュボードへ移動する必要がありました。CSVインポート後にそのまま配当の可視化を確認できるようにし、導線の分断を解消します。

## 変更内容

- `src/web/src/routes/Dividends.tsx` のみ変更
- 既存の `DividendChart` / `DividendAllocationChart`（`components/dashboard/`）をそのまま再利用（DRY）
- ダッシュボードと同じSWRキー（`dividends-monthly` / `dividends-by-symbol`）を使用し、キャッシュを共有して追加のネットワーク負荷を回避
- 見出しの下・テーブルの上に2カラムグリッドでグラフを配置
- Refreshボタンでグラフ用データも併せて再取得

バックエンドの変更はありません（対象エンドポイントはダッシュボードで利用済み）。

## 検証

- `pnpm check`（Biome lint/format/typecheck/knip）通過
- `pnpm test`（171 tests）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xVLnULAwRDxaGd6B1xTpa)_