### PR TITLE
Add unit lot indicators to holdings

### DIFF
--- a/src/api/alembic/versions/1f2e3d4c5b6a_add_transactions_account_holdings_index.py
+++ b/src/api/alembic/versions/1f2e3d4c5b6a_add_transactions_account_holdings_index.py
@@ -1,0 +1,30 @@
+"""add transactions account holdings index
+
+Revision ID: 1f2e3d4c5b6a
+Revises: 7b1c2d3e4f5a
+Create Date: 2026-07-10 11:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1f2e3d4c5b6a"
+down_revision: Union[str, None] = "7b1c2d3e4f5a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_transactions_user_symbol_account_type",
+        "transactions",
+        ["user_id", "symbol", "account_type"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transactions_user_symbol_account_type", table_name="transactions")

--- a/src/api/stock/models.py
+++ b/src/api/stock/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     UniqueConstraint,
@@ -216,6 +217,8 @@ class Transaction(Base):
 
     user = relationship("User", back_populates="transactions")
     stock = relationship("Stock", back_populates="transactions")
+
+    __table_args__ = (Index("ix_transactions_user_symbol_account_type", "user_id", "symbol", "account_type"),)
 
 
 class PortfolioHistory(Base):

--- a/src/api/stock/schemas.py
+++ b/src/api/stock/schemas.py
@@ -174,6 +174,11 @@ class HoldingNoteUpdate(BaseModel):
     note: Optional[str] = Field(None, max_length=2000)
 
 
+class AccountHolding(BaseModel):
+    account_type: AccountType
+    quantity: float
+
+
 class Holding(HoldingBase):
     user_id: int
     last_updated: datetime
@@ -182,6 +187,7 @@ class Holding(HoldingBase):
     currency: Optional[str] = None
     country: Optional[str] = None
     sector_name: Optional[str] = None
+    account_holdings: List[AccountHolding] = Field(default_factory=list)
     model_config = ConfigDict(from_attributes=True)
 
     @field_serializer("last_updated")

--- a/src/api/stock/services/holding_service.py
+++ b/src/api/stock/services/holding_service.py
@@ -1,13 +1,13 @@
 from typing import List, NamedTuple, Optional
 
 from loguru import logger
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from .. import models
 from ..models import Holding, Stock
-from ..schemas import SecurityType
+from ..schemas import AccountType, SecurityType
 from ..services import alphavantage_service, investment_trust_service
 from .stock_price_fetcher import (
     fetch_japan_stock_prices,
@@ -384,6 +384,7 @@ async def update_single_holding_pl(db: AsyncSession, user_id: int, symbol: str) 
     else:
         logger.info("Holdingsを更新できませんでした action=update user_id={} symbol={}", user_id, symbol)
 
+    await enrich_holdings_with_account_holdings(db, user_id, [holding])
     return holding
 
 
@@ -484,6 +485,58 @@ def _derive_country_and_sector(stock: Stock) -> tuple[Optional[str], Optional[st
     return country, sector_name
 
 
+async def _get_account_holdings_by_symbol(
+    db: AsyncSession, user_id: int, symbols: list[str]
+) -> dict[str, list[dict[str, float | str]]]:
+    if not symbols:
+        return {}
+
+    quantity = func.coalesce(models.Transaction.adjusted_quantity, models.Transaction.quantity)
+    signed_quantity = case(
+        (models.Transaction.transaction_type == "buy", quantity),
+        else_=-quantity,
+    )
+    query = (
+        select(
+            models.Transaction.symbol,
+            models.Transaction.account_type,
+            func.sum(signed_quantity).label("quantity"),
+        )
+        .where(
+            models.Transaction.user_id == user_id,
+            models.Transaction.symbol.in_(symbols),
+        )
+        .group_by(models.Transaction.symbol, models.Transaction.account_type)
+    )
+    result = await db.execute(query)
+
+    account_holdings_by_symbol: dict[str, list[dict[str, float | str]]] = {}
+    for row in result:
+        account_quantity = float(row.quantity or 0)
+        if account_quantity <= 0:
+            continue
+        account_holdings_by_symbol.setdefault(row.symbol, []).append(
+            {"account_type": row.account_type, "quantity": account_quantity}
+        )
+
+    account_type_order = [account_type.value for account_type in AccountType]
+    order_by_account_type = {account_type: index for index, account_type in enumerate(account_type_order)}
+    for account_holdings in account_holdings_by_symbol.values():
+        account_holdings.sort(key=lambda item: order_by_account_type.get(str(item["account_type"]), 999))
+    return account_holdings_by_symbol
+
+
+async def enrich_holdings_with_account_holdings(
+    db: AsyncSession, user_id: int, holdings: list[Holding]
+) -> list[Holding]:
+    account_holdings_by_symbol = await _get_account_holdings_by_symbol(
+        db, user_id, [holding.symbol for holding in holdings]
+    )
+    for holding in holdings:
+        holding.account_holdings = account_holdings_by_symbol.get(holding.symbol, [])
+    return holdings
+
+
 async def list_holdings(db: AsyncSession, user_id: int, symbol: Optional[str] = None) -> List[Holding]:
     """
     ユーザーの保有銘柄一覧を銘柄名、証券種別、通貨、国、セクターと共に取得します。
@@ -517,6 +570,7 @@ async def list_holdings(db: AsyncSession, user_id: int, symbol: Optional[str] = 
         holding.security_type = holding.stock.security_type
         holding.currency = holding.stock.currency
         holding.country, holding.sector_name = _derive_country_and_sector(holding.stock)
+    await enrich_holdings_with_account_holdings(db, user_id, list(holdings))
     logger.info(
         "Holdingsを取得しました action=select user_id={} symbol={} count={}",
         user_id,

--- a/src/api/tests/api/test_holdings.py
+++ b/src/api/tests/api/test_holdings.py
@@ -37,6 +37,7 @@ async def test_recalculate_holding_pl_japanese_stock(
     assert data["unrealized_pl_percentage"] is not None
     assert data["total_pl"] is not None
     assert data["total_pl_percentage"] is not None
+    assert data["account_holdings"] == [{"account_type": "NISA(成長投資枠)", "quantity": 100.0}]
 
 
 @pytest.mark.asyncio
@@ -77,7 +78,11 @@ async def test_recalculate_holding_pl_us_stock(
 
 @pytest.mark.asyncio
 async def test_list_holdings(
-    client: AsyncClient, db_session: AsyncSession, auth_token: str, setup_japanese_stock_data
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_token: str,
+    setup_japanese_stock_data,
+    create_transaction,
 ):
     """保有銘柄一覧取得を確認するテスト
 
@@ -91,6 +96,31 @@ async def test_list_holdings(
         auth_token: 認証トークン
         setup_japanese_stock_data: 日本株のテストデータ
     """
+    await create_transaction(
+        {
+            "symbol": "8058",
+            "transaction_type": "buy",
+            "quantity": "30.0",
+            "price": "3000.0",
+            "account_type": "特定",
+            "fee": "0.0",
+            "tax": "0.0",
+            "transaction_date": "2024-01-02T00:00:00",
+        }
+    )
+    await create_transaction(
+        {
+            "symbol": "8058",
+            "transaction_type": "sell",
+            "quantity": "10.0",
+            "price": "3200.0",
+            "account_type": "特定",
+            "fee": "0.0",
+            "tax": "0.0",
+            "transaction_date": "2024-01-03T00:00:00",
+        }
+    )
+
     # 保有銘柄一覧を取得
     response = await client.get("/api/v1/holdings/")
 
@@ -98,12 +128,17 @@ async def test_list_holdings(
     assert response.status_code == 200
     data = response.json()
     assert len(data) > 0
-    assert data[0]["stock_name"] == "三菱商事"
-    assert data[0]["security_type"] == "STOCK"
-    assert data[0]["currency"] == "JPY"
+    target = next(h for h in data if h["symbol"] == "8058")
+    assert target["stock_name"] == "三菱商事"
+    assert target["security_type"] == "STOCK"
+    assert target["currency"] == "JPY"
     # JPY建ての日本株は country=="JP"、JQuants から取得した 17 業種名が sector_name に入る
-    assert data[0]["country"] == "JP"
-    assert data[0]["sector_name"] == "商社・卸売"
+    assert target["country"] == "JP"
+    assert target["sector_name"] == "商社・卸売"
+    assert target["account_holdings"] == [
+        {"account_type": "NISA(成長投資枠)", "quantity": 100.0},
+        {"account_type": "特定", "quantity": 20.0},
+    ]
 
 
 @pytest.mark.asyncio

--- a/src/web/src/components/dashboard/holdings-table.test.tsx
+++ b/src/web/src/components/dashboard/holdings-table.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { MemoryRouter } from "react-router"
+import { describe, expect, it } from "vitest"
+import { createHolding } from "@/test/factories"
+import { HoldingsTable } from "./holdings-table"
+
+function renderTable(holdings = [createHolding()]) {
+  return render(
+    <MemoryRouter>
+      <HoldingsTable holdings={holdings} isLoading={false} />
+    </MemoryRouter>
+  )
+}
+
+describe("HoldingsTable", () => {
+  it("ジュニアNISA以外の数量を合算して単元ありをアイコンで表示する", () => {
+    renderTable([
+      createHolding({
+        symbol: "8058",
+        stock_name: "三菱商事",
+        country: "JP",
+        security_type: "STOCK",
+        account_holdings: [
+          { account_type: "NISA(成長投資枠)", quantity: 80 },
+          { account_type: "特定", quantity: 20 },
+        ],
+      }),
+    ])
+
+    expect(screen.getByLabelText("単元あり。その他: 100株")).toBeInTheDocument()
+  })
+
+  it("ジュニアNISAはその他口座と合算せずに単元判定する", () => {
+    renderTable([
+      createHolding({
+        symbol: "8058",
+        stock_name: "三菱商事",
+        country: "JP",
+        security_type: "STOCK",
+        account_holdings: [
+          { account_type: "ジュニアNISA", quantity: 50 },
+          { account_type: "特定", quantity: 50 },
+        ],
+      }),
+    ])
+
+    expect(screen.getByLabelText("単元未満。ジュニアNISA: 50株 / その他: 50株")).toBeInTheDocument()
+  })
+
+  it("単元列で単元ありの日本株を上位に並び替えられる", async () => {
+    const user = userEvent.setup()
+    renderTable([
+      createHolding({
+        symbol: "LESS",
+        stock_name: "単元未満",
+        country: "JP",
+        security_type: "STOCK",
+        market_value: 300000,
+        account_holdings: [{ account_type: "特定", quantity: 99 }],
+      }),
+      createHolding({
+        symbol: "FULL",
+        stock_name: "単元あり",
+        country: "JP",
+        security_type: "STOCK",
+        market_value: 200000,
+        account_holdings: [
+          { account_type: "NISA(成長投資枠)", quantity: 80 },
+          { account_type: "特定", quantity: 20 },
+        ],
+      }),
+      createHolding({
+        symbol: "AAPL",
+        stock_name: "Apple",
+        country: "US",
+        security_type: "STOCK",
+        market_value: 100000,
+        account_holdings: [{ account_type: "特定", quantity: 10 }],
+      }),
+    ])
+
+    await user.click(screen.getByText("単元"))
+
+    const rows = screen.getAllByRole("row").slice(1)
+    expect(rows[0]).toHaveTextContent("単元あり")
+    expect(rows[1]).toHaveTextContent("単元未満")
+    expect(rows[2]).toHaveTextContent("Apple")
+  })
+})

--- a/src/web/src/components/dashboard/holdings-table.tsx
+++ b/src/web/src/components/dashboard/holdings-table.tsx
@@ -1,6 +1,8 @@
+import { CircleCheck, CircleMinus } from "lucide-react"
 import { Link } from "react-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useTableSort } from "@/hooks/use-table-sort"
 import type { Holding } from "@/lib/api/types"
 import {
@@ -10,6 +12,7 @@ import {
   formatPercentOrDash,
   getPLColorClass,
 } from "@/lib/format"
+import { getLotStatusSortValue, getUnitLotGroups, hasUnitLot, isJapaneseStock } from "@/lib/holding-lot"
 
 interface HoldingsTableProps {
   holdings: Holding[] | undefined
@@ -20,11 +23,47 @@ interface HoldingsTableProps {
 type SortKey =
   | "symbol"
   | "quantity"
+  | "lot_status"
   | "current_price"
   | "market_value"
   | "total_pl"
   | "total_pl_percentage"
   | "weekly_change"
+
+function UnitLotIndicator({ holding }: { holding: Holding }) {
+  if (!isJapaneseStock(holding)) {
+    return <span className="text-muted-foreground">-</span>
+  }
+
+  const hasUnit = hasUnitLot(holding)
+  const unitLotGroups = getUnitLotGroups(holding)
+  const accountBreakdown =
+    unitLotGroups.length > 0
+      ? unitLotGroups.map((group) => `${group.label}: ${group.quantity.toLocaleString()}株`).join(" / ")
+      : "口座別数量なし"
+  const label = hasUnit ? `単元あり。${accountBreakdown}` : `単元未満。${accountBreakdown}`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={label}
+          role="img"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground"
+        >
+          {hasUnit ? (
+            <CircleCheck className="h-5 w-5 text-emerald-600" aria-hidden="true" />
+          ) : (
+            <CircleMinus className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          )}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
 
 export function HoldingsTable({ holdings, isLoading, weeklyChangeMap }: HoldingsTableProps) {
   const { sortKey, sortDirection, handleSort, getSortIcon } = useTableSort<SortKey>({
@@ -46,6 +85,10 @@ export function HoldingsTable({ holdings, isLoading, weeklyChangeMap }: Holdings
         case "quantity":
           aValue = a.quantity
           bValue = b.quantity
+          break
+        case "lot_status":
+          aValue = getLotStatusSortValue(a)
+          bValue = getLotStatusSortValue(b)
           break
         case "current_price":
           aValue = a.current_price ?? 0
@@ -109,6 +152,15 @@ export function HoldingsTable({ holdings, isLoading, weeklyChangeMap }: Holdings
                     <div className="flex items-center justify-end">
                       株数
                       {getSortIcon("quantity")}
+                    </div>
+                  </TableHead>
+                  <TableHead
+                    className="w-16 cursor-pointer select-none text-center"
+                    onClick={() => handleSort("lot_status")}
+                  >
+                    <div className="flex items-center justify-center">
+                      単元
+                      {getSortIcon("lot_status")}
                     </div>
                   </TableHead>
                   <TableHead
@@ -180,6 +232,9 @@ export function HoldingsTable({ holdings, isLoading, weeklyChangeMap }: Holdings
                           </Link>
                         </TableCell>
                         <TableCell className="text-right">{holding.quantity.toLocaleString()}</TableCell>
+                        <TableCell className="text-center">
+                          <UnitLotIndicator holding={holding} />
+                        </TableCell>
                         <TableCell className="text-right">
                           <div>
                             <div>
@@ -222,7 +277,7 @@ export function HoldingsTable({ holdings, isLoading, weeklyChangeMap }: Holdings
                   })
                 ) : (
                   <TableRow>
-                    <TableCell colSpan={7} className="text-center text-muted-foreground">
+                    <TableCell colSpan={8} className="text-center text-muted-foreground">
                       保有銘柄がありません
                     </TableCell>
                   </TableRow>

--- a/src/web/src/lib/api/types.ts
+++ b/src/web/src/lib/api/types.ts
@@ -62,6 +62,12 @@ export interface Holding {
   country: "JP" | "US" | "OTHER" | null
   sector_name: string | null
   note: string | null
+  account_holdings: AccountHolding[]
+}
+
+interface AccountHolding {
+  account_type: AccountType
+  quantity: number
 }
 
 // Transactions

--- a/src/web/src/lib/holding-lot.test.ts
+++ b/src/web/src/lib/holding-lot.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { createHolding } from "@/test/factories"
+import { getLotStatusSortValue, getUnitLotGroups, hasUnitLot } from "./holding-lot"
+
+describe("holding-lot", () => {
+  it("ジュニアNISA以外の数量を合算して単元判定する", () => {
+    const holding = createHolding({
+      country: "JP",
+      security_type: "STOCK",
+      account_holdings: [
+        { account_type: "NISA(成長投資枠)", quantity: 80 },
+        { account_type: "特定", quantity: 20 },
+      ],
+    })
+
+    expect(getUnitLotGroups(holding)).toEqual([{ label: "その他", quantity: 100 }])
+    expect(hasUnitLot(holding)).toBe(true)
+    expect(getLotStatusSortValue(holding)).toBe(2)
+  })
+
+  it("ジュニアNISAはその他口座と合算しない", () => {
+    const holding = createHolding({
+      country: "JP",
+      security_type: "STOCK",
+      account_holdings: [
+        { account_type: "ジュニアNISA", quantity: 50 },
+        { account_type: "特定", quantity: 50 },
+      ],
+    })
+
+    expect(getUnitLotGroups(holding)).toEqual([
+      { label: "ジュニアNISA", quantity: 50 },
+      { label: "その他", quantity: 50 },
+    ])
+    expect(hasUnitLot(holding)).toBe(false)
+    expect(getLotStatusSortValue(holding)).toBe(1)
+  })
+
+  it("日本株以外は単元判定の対象外にする", () => {
+    const holding = createHolding({
+      country: "US",
+      security_type: "STOCK",
+      account_holdings: [{ account_type: "特定", quantity: 100 }],
+    })
+
+    expect(hasUnitLot(holding)).toBe(false)
+    expect(getLotStatusSortValue(holding)).toBe(0)
+  })
+})

--- a/src/web/src/lib/holding-lot.ts
+++ b/src/web/src/lib/holding-lot.ts
@@ -1,0 +1,44 @@
+import type { Holding } from "@/lib/api/types"
+
+const JAPANESE_STOCK_UNIT = 100
+const JUNIOR_NISA_ACCOUNT_TYPE = "ジュニアNISA"
+
+export interface UnitLotGroup {
+  label: string
+  quantity: number
+}
+
+export function isJapaneseStock(holding: Holding) {
+  return holding.country === "JP" && holding.security_type === "STOCK"
+}
+
+export function getUnitLotGroups(holding: Holding): UnitLotGroup[] {
+  let juniorNisaQuantity = 0
+  let otherQuantity = 0
+
+  for (const account of holding.account_holdings) {
+    if (account.account_type === JUNIOR_NISA_ACCOUNT_TYPE) {
+      juniorNisaQuantity += account.quantity
+    } else {
+      otherQuantity += account.quantity
+    }
+  }
+
+  return [
+    { label: JUNIOR_NISA_ACCOUNT_TYPE, quantity: juniorNisaQuantity },
+    { label: "その他", quantity: otherQuantity },
+  ].filter((group) => group.quantity > 0)
+}
+
+export function hasUnitLot(holding: Holding) {
+  return (
+    isJapaneseStock(holding) &&
+    getUnitLotGroups(holding).some((group) => group.quantity >= JAPANESE_STOCK_UNIT)
+  )
+}
+
+export function getLotStatusSortValue(holding: Holding) {
+  if (!isJapaneseStock(holding)) return 0
+  if (hasUnitLot(holding)) return 2
+  return 1
+}

--- a/src/web/src/test/factories.ts
+++ b/src/web/src/test/factories.ts
@@ -28,6 +28,7 @@ export function createHolding(overrides: Partial<Holding> = {}): Holding {
     country: null,
     sector_name: null,
     note: null,
+    account_holdings: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Add account-level holding quantities to the holdings API response, derived from transactions without adding storage columns.
- Show a compact unit-lot indicator in the holdings table with tooltip details.
- Treat Junior NISA separately and combine all other account types for unit-lot judgement.
- Add a transactions index for the account holdings aggregation query.

## Validation
- `uv run ruff check --fix`
- `uv run pytest tests/api/test_holdings.py`
- `pnpm check`
- `pnpm test`
- `uv run alembic upgrade head`