### PR TITLE
fix(api): price_history_repoの日付境界をJST基準にする

### DIFF
--- a/src/api/stock/services/price_history_repo.py
+++ b/src/api/stock/services/price_history_repo.py
@@ -4,7 +4,7 @@
 """
 
 from collections.abc import Sequence
-from datetime import date, timedelta
+from datetime import timedelta
 
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -15,9 +15,7 @@ from ..models import PriceHistory, get_jst_now
 
 async def get_recent_prices(db: AsyncSession, symbol: str, days_back: int) -> list[dict]:
     """直近 N カレンダー日分の価格を日付昇順で返す。該当が無ければ空リスト。"""
-    # TODO: JST基準に直す。date.today() はサーバーのローカルTZ依存で、UTC環境では
-    # JST 00:00-09:00 の間だけ日付が1日前になる。挙動変更を伴うため別PRで対応する
-    threshold = date.today() - timedelta(days=days_back)  # noqa: DTZ011
+    threshold = get_jst_now().date() - timedelta(days=days_back)
     result = await db.execute(
         select(PriceHistory)
         .where(PriceHistory.symbol == symbol)
@@ -76,8 +74,7 @@ async def upsert_prices(db: AsyncSession, symbol: str, rows: Sequence[dict]) -> 
 
 async def prune_old_prices(db: AsyncSession, symbol: str, keep_days: int = 21) -> int:
     """keep_days より古い行を削除。削除件数を返す。"""
-    # TODO: JST基準に直す。理由は get_recent_prices と同じ
-    threshold = date.today() - timedelta(days=keep_days)  # noqa: DTZ011
+    threshold = get_jst_now().date() - timedelta(days=keep_days)
     result = await db.execute(
         delete(PriceHistory).where(PriceHistory.symbol == symbol).where(PriceHistory.date < threshold)
     )

--- a/src/api/tests/services/test_price_history_repo.py
+++ b/src/api/tests/services/test_price_history_repo.py
@@ -1,11 +1,11 @@
 """price_history_repo のテスト"""
 
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stock.models import Stock
+from stock.models import JST, Stock
 from stock.services import price_history_repo
 
 
@@ -102,3 +102,44 @@ async def test_prune_old_prices_removes_only_old_rows(db_session: AsyncSession):
 
     remaining = await price_history_repo.get_recent_prices(db_session, "8058", days_back=60)
     assert len(remaining) == 2
+
+
+# JST 2024-12-01 00:30 は UTC では 2024-11-30 15:30。
+# サーバがUTCで動いていると日付が1日前になり、境界が1日ずれる。
+_JST_BOUNDARY_NOW = datetime(2024, 12, 1, 0, 30, tzinfo=JST)
+
+
+@pytest.mark.asyncio
+async def test_get_recent_prices_respects_jst_boundary(db_session: AsyncSession, monkeypatch):
+    """JST 0時台でも下限日が JST の日付基準で決まること
+
+    UTC 基準だと threshold が 2024-11-29 になり、11/29 の行まで拾ってしまう。
+    """
+    assert _JST_BOUNDARY_NOW.astimezone(UTC).date() == date(2024, 11, 30)
+    monkeypatch.setattr(price_history_repo, "get_jst_now", lambda: _JST_BOUNDARY_NOW)
+
+    await _create_stock(db_session)
+    rows = [_make_row(date(2024, 11, 29)), _make_row(date(2024, 11, 30)), _make_row(date(2024, 12, 1))]
+    await price_history_repo.upsert_prices(db_session, "8058", rows)
+
+    fetched = await price_history_repo.get_recent_prices(db_session, "8058", days_back=1)
+    assert [r["date"] for r in fetched] == [date(2024, 11, 30), date(2024, 12, 1)]
+
+
+@pytest.mark.asyncio
+async def test_prune_old_prices_respects_jst_boundary(db_session: AsyncSession, monkeypatch):
+    """JST 0時台でも削除境界が JST の日付基準で決まること
+
+    UTC 基準だと threshold が 2024-11-29 になり、11/29 の行が削除されずに残る。
+    """
+    monkeypatch.setattr(price_history_repo, "get_jst_now", lambda: _JST_BOUNDARY_NOW)
+
+    await _create_stock(db_session)
+    rows = [_make_row(date(2024, 11, 29)), _make_row(date(2024, 11, 30)), _make_row(date(2024, 12, 1))]
+    await price_history_repo.upsert_prices(db_session, "8058", rows)
+
+    deleted = await price_history_repo.prune_old_prices(db_session, "8058", keep_days=1)
+    assert deleted == 1
+
+    remaining = await price_history_repo.get_recent_prices(db_session, "8058", days_back=30)
+    assert [r["date"] for r in remaining] == [date(2024, 11, 30), date(2024, 12, 1)]


### PR DESCRIPTION
## 概要

`price_history_repo` の `get_recent_prices` と `prune_old_prices` が使っている `date.today()` を、JST基準の日付に修正します。

`date.today()` はサーバーのローカルタイムゾーンに依存します。本番コンテナがUTCで動いている場合、**JST 00:00〜09:00 の間は日付が1日前**になり、以下がずれます。

| 関数 | ずれる箇所 | UTC環境での影響 |
|------|-----------|----------------|
| `get_recent_prices` | 直近Nカレンダー日分の下限日 | 1日古い行まで余分に取得する |
| `prune_old_prices` | `keep_days` より古い行の削除境界 | 削除すべき行が1日分残る |

同ファイルは `from ..models import PriceHistory, get_jst_now` で既にJST用の関数をimportしており、`upsert_prices` の `last_updated` では使っていました。日付境界でも同じ関数を使うようにします。

## 変更内容

### `src/api/stock/services/price_history_repo.py`

- `date.today()` → `get_jst_now().date()`（2箇所）。`get_jst_now()` は `datetime.now(JST)` を返すtz-awareな値なので、`.date()` でJST基準の日付になります
- 別PR対応としていたTODOコメントと `# noqa: DTZ011` を削除
- 未使用になった `date` を import から削除

### `src/api/tests/services/test_price_history_repo.py`

JST境界の挙動を検証するテストを2件追加しました。

- `test_get_recent_prices_respects_jst_boundary`
- `test_prune_old_prices_respects_jst_boundary`

いずれも `get_jst_now` を **JST 2024-12-01 00:30（= UTC 2024-11-30 15:30）** に monkeypatch し、11/29・11/30・12/1 の3行を投入して境界を確認します。UTC基準だと threshold が1日前倒しになるため、取得では 11/29 が混入し、削除では 11/29 が残ります。

## 経緯

ruff 0.16 のデフォルトルール拡張（#425）で DTZ011 が有効になり発見されたものです。lint設定の変更と挙動変更を混ぜると追跡が困難なため #425 では noqa + TODO で先送りされており、判断の経緯は `docs/adr/0002-ruff-default-ruleset-adoption.md` に記録されています。本PRがその先送り分の解消にあたります。

## 検証

- `uv run ruff check` / `uv run ruff format --check`: いずれも通過（ruff 0.16.0）
- 全テスト: **184 passed**（`TC_HOST=127.0.0.1 uv run pytest -n auto -q`、約67秒）
- 追加テストの有効性: 実装を一時的に `get_jst_now().astimezone(UTC).date()` に差し替えると2件とも FAILED になることを確認済み。単にモックが効いているだけでなく、JST基準かUTC基準かを判別できるテストになっています

## レビュー時の補足

- 既存テストの `date.today()` はそのままです。`[tool.ruff.lint.per-file-ignores]` で `tests/**` は DTZ011 が ignore されているため lint 上の問題はなく、テストローカルな用途なので変更していません
- `docs/adr/0002-ruff-default-ruleset-adoption.md` に「別PRで対応」相当の記述が残っている場合、本PRのマージ後に更新するかはお任せします（本PRでは触っていません）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
