### PR TITLE
feat(web,api): APIをVercel Function経由の同一オリジン構成にしてCORSを撤廃

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,21 @@ Cookie(httponly) ベースの認証に一本化。`/api/v1/token` がログイ�
 | Webフロントエンド | Cookie(httponly) | ブラウザからのアクセス |
 | Swagger UI (/docs) | Cookie(httponly) | `/api/v1/token` を Try it out でログイン後、Cookieが自動付与される |
 
+Cookie は `SameSite=Lax` / `HttpOnly` / `Secure`（本番のみ）で発行する。Webフロントとは同一オリジンで
+やり取りするため `SameSite=None` は不要で、クロスサイトからのCSRFはブラウザ側で遮断される。
+
+### フロントエンドからのAPI呼び出し経路
+
+Webフロントは API を絶対URLでは呼ばず、**同一オリジンの `/api` 配下**を叩く。中継は環境ごとに以下が担う。
+
+| 環境 | 中継 | 転送先の指定 |
+|------|------|-------------|
+| 本番(Vercel) | Vercel Function `src/web/api/[...path].ts` | Vercelの環境変数 `API_ORIGIN` |
+| ローカル | Vite開発サーバのプロキシ (`vite.config.ts`) | 環境変数 `DEV_API_PROXY_TARGET`（既定 `http://localhost:8000`） |
+
+この構成により API 側は CORS ミドルウェアを持たない。**フロント側に絶対URLを書き戻したり、
+API に CORS 設定を復活させたりしないこと**（同一オリジン前提が崩れ、`SameSite=None` が再び必要になる）。
+
 ### パスワードハッシュ
 
 - **アルゴリズム**: Argon2id（OWASP推奨）

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ docker compose exec api uv run python -m stock.jobs.update_and_notify
 ```bash
 cd src/web
 sfw pnpm install
-cp .env.local.example .env.local
 pnpm dev
 ```
 
-- `VITE_API_URL` が API のURL（デフォルトは `http://localhost:8000`）
 - 起動後のURLはViteの表示（通常は `http://localhost:5173`）に従ってください
+- APIはVite開発サーバの `/api` プロキシ経由で呼ばれます。転送先の既定は `http://localhost:8000` で、
+  変えたい場合のみ環境変数 `DEV_API_PROXY_TARGET` を指定してください
 
 ## 開発（詳細）
 
@@ -120,7 +120,6 @@ uv run uvicorn stock.app:app --reload --port 8000
 
 - `src/docker-compose.yaml` のDBは `POSTGRES_PASSWORD=hogehoge` が固定です。DockerのDBを使う場合は
   `src/api/.env` の `DB_PASSWORD` を合わせるか、`src/docker-compose.yaml` を修正してください。
-- フロント開発サーバのオリジンに合わせて `CORS_ORIGINS` を設定してください（Vite既定は `http://localhost:5173`）。
 
 ### Frontend（`src/web`）
 
@@ -133,7 +132,7 @@ pnpm check
 ## 環境変数
 
 - Backend: `src/api/.env.sample` を参考に `src/api/.env` を作成
-- Frontend: `src/web/.env.local.example` を参考に `src/web/.env.local` を作成
+- Frontend: ローカル開発では設定不要。Vercel側でのみ、APIの転送先として `API_ORIGIN` を設定する
 
 ## API仕様
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -23,9 +23,6 @@ TF_VAR_image_uri="asia-northeast1-docker.pkg.dev/your-gcp-project-id/cloud-run-s
 TF_VAR_db_user="<DB_USER の値>"
 TF_VAR_db_host="<DB_HOST の値>"
 
-# CORS_ORIGINS（HCL 側で jsonencode するので、ここでは JSON 配列形式で渡す）
-TF_VAR_cors_origins='["https://example.com","http://localhost:5173"]'
-
 # CD (GitHub Actions) 用。WIF の attribute_condition で repository を絞るため必須。
 TF_VAR_github_repository="<github-owner>/<repo>"
 

--- a/infra/cloud_run_service.tf
+++ b/infra/cloud_run_service.tf
@@ -55,10 +55,6 @@ resource "google_cloud_run_v2_service" "api" {
         name  = "DB_NAME"
         value = var.db_name
       }
-      env {
-        name  = "CORS_ORIGINS"
-        value = jsonencode(var.cors_origins)
-      }
 
       dynamic "env" {
         for_each = local.service_secrets

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -18,11 +18,6 @@ variable "db_host" {
   description = "Supabase の pooler ホスト。"
 }
 
-variable "cors_origins" {
-  type        = list(string)
-  description = "Cloud Run Service の CORS_ORIGINS に渡す URL リスト。"
-}
-
 variable "region" {
   type        = string
   default     = "asia-northeast1"

--- a/src/api/.env.sample
+++ b/src/api/.env.sample
@@ -25,6 +25,3 @@ OPENAI_API_KEY=your-openai-api-key  # 投資信託の通貨分類に使用
 
 # LINE settings
 LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token  # LINE Messaging APIのチャネルアクセストークン
-
-# CORS settings
-CORS_ORIGINS=["http://localhost:3000"]  # フロントエンドのオリジンに合わせて設定してください

--- a/src/api/stock/app.py
+++ b/src/api/stock/app.py
@@ -4,10 +4,8 @@ FastAPIアプリケーション定義
 """
 
 from fastapi import FastAPI, Request, status
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from .database import settings
 from .routes import (
     auth,
     dividends,
@@ -28,15 +26,8 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORSミドルウェアの設定
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
-    allow_origin_regex=r"^https://.+-tomodo1773s-projects\.vercel\.app$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# CORSミドルウェアは持たない。Webフロントは同一オリジンの /api をVercel Functionで中継しており、
+# ブラウザからのクロスオリジンリクエストを許可する必要がないため。
 
 
 # ドメインエラーからHTTPレスポンスへの変換をここに集約する。

--- a/src/api/stock/database.py
+++ b/src/api/stock/database.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 
 from pydantic import field_validator
@@ -51,9 +50,6 @@ class Settings(BaseSettings):
     # OpenAI API設定
     OPENAI_API_KEY: str = ""
 
-    # CORS設定
-    CORS_ORIGINS: list[str] = ["http://localhost:3000"]
-
     # サーバー設定
     HOST: str = "0.0.0.0"
     PORT: int = 8000
@@ -67,17 +63,6 @@ class Settings(BaseSettings):
         if self.DATABASE_URL:
             return self.DATABASE_URL
         return f"postgresql+asyncpg://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
-
-    @field_validator("CORS_ORIGINS", mode="before")
-    @classmethod
-    def parse_cors_origins(cls, v: str | list[str]) -> list[str]:
-        """CORS_ORIGINSをJSON文字列からリストに変換"""
-        if isinstance(v, str):
-            try:
-                return json.loads(v)
-            except json.JSONDecodeError:
-                return [i.strip() for i in v.split(",")]
-        return v
 
     @field_validator("PORT", "ACCESS_TOKEN_EXPIRE_MINUTES", mode="before")
     @classmethod

--- a/src/api/stock/routes/auth.py
+++ b/src/api/stock/routes/auth.py
@@ -37,14 +37,14 @@ async def login_for_access_token(
 
     access_token = create_access_token(data={"sub": user.username})
 
-    # 環境に応じてCookie設定を変更
-    is_production = ENVIRONMENT.lower() == "production"
+    # フロントとは同一オリジン（Vercel Functionが /api を中継）でやり取りするため、
+    # SameSite=Lax のままで動く。クロスサイトからのCSRFはブラウザ側で遮断される。
     response.set_cookie(
         key="token",
         value=access_token,
         httponly=True,
-        secure=is_production,
-        samesite="none" if is_production else "lax",
+        secure=ENVIRONMENT.lower() == "production",
+        samesite="lax",
         max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # 分を秒に変換
         path="/",
     )

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -49,7 +49,8 @@ services:
     image: investlogix-web
     container_name: investlogix-web
     environment:
-      VITE_API_URL: http://localhost:8000
+      # Vite開発サーバのプロキシがコンテナ内から中継するため、サービス名で解決する
+      DEV_API_PROXY_TARGET: http://api:8000
     volumes:
       - ./web:/app
       - /app/node_modules

--- a/src/web/api/[...path].ts
+++ b/src/web/api/[...path].ts
@@ -4,8 +4,10 @@
  * ブラウザからは常に同一オリジンへのリクエストになるため、API側でCORSを設定する必要がなく、
  * 認証Cookieもファーストパーティ（SameSite=Lax）で扱える。
  * 転送先はVercelの環境変数 API_ORIGIN から読む（リポジトリにバックエンドのURLを残さないため）。
+ *
+ * ランタイムはVercelの既定（Node.js）を使う。Web標準のRequest/Responseで書けるため
+ * ランタイム指定は不要で、指定しないぶん構成の陳腐化にも強い。
  */
-export const config = { runtime: "edge" }
 
 /** ボディを持てないメソッド。fetchにbodyを渡すとTypeErrorになる */
 const BODYLESS_METHODS = new Set(["GET", "HEAD"])

--- a/src/web/api/[...path].ts
+++ b/src/web/api/[...path].ts
@@ -1,0 +1,59 @@
+/**
+ * バックエンドAPIへのリバースプロキシ。
+ *
+ * ブラウザからは常に同一オリジンへのリクエストになるため、API側でCORSを設定する必要がなく、
+ * 認証Cookieもファーストパーティ（SameSite=Lax）で扱える。
+ * 転送先はVercelの環境変数 API_ORIGIN から読む（リポジトリにバックエンドのURLを残さないため）。
+ */
+export const config = { runtime: "edge" }
+
+/** ボディを持てないメソッド。fetchにbodyを渡すとTypeErrorになる */
+const BODYLESS_METHODS = new Set(["GET", "HEAD"])
+
+/**
+ * 転送するとレスポンスが壊れるリクエストヘッダ。
+ * accept-encodingを落とすのは、圧縮の有無をランタイムに一任して
+ * 「本文はデコード済みなのにcontent-encodingが残る」状態を避けるため。
+ */
+const STRIPPED_REQUEST_HEADERS = ["host", "connection", "content-length", "accept-encoding"]
+
+/** 本文を再構築するため、長さ・圧縮・転送方式を示すヘッダは引き継がない */
+const STRIPPED_RESPONSE_HEADERS = ["content-encoding", "content-length", "transfer-encoding"]
+
+export default async function handler(request: Request): Promise<Response> {
+  const apiOrigin = process.env.API_ORIGIN
+  if (!apiOrigin) {
+    return Response.json({ detail: "API_ORIGIN が設定されていません" }, { status: 500 })
+  }
+
+  const url = new URL(request.url)
+  const requestHeaders = new Headers(request.headers)
+  for (const name of STRIPPED_REQUEST_HEADERS) {
+    requestHeaders.delete(name)
+  }
+
+  const upstream = await fetch(`${apiOrigin}${url.pathname}${url.search}`, {
+    method: request.method,
+    headers: requestHeaders,
+    body: BODYLESS_METHODS.has(request.method) ? undefined : await request.arrayBuffer(),
+    redirect: "manual",
+  })
+
+  const responseHeaders = new Headers(upstream.headers)
+  for (const name of STRIPPED_RESPONSE_HEADERS) {
+    responseHeaders.delete(name)
+  }
+
+  // FastAPIの末尾スラッシュ補正などが返す絶対URLはバックエンドのオリジンを含む。
+  // そのまま返すとブラウザがバックエンドへ直接リダイレクトしてしまうので相対パスに直す。
+  const location = responseHeaders.get("location")
+  if (location?.startsWith(apiOrigin)) {
+    responseHeaders.set("location", location.slice(apiOrigin.length) || "/")
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  })
+}

--- a/src/web/knip.json
+++ b/src/web/knip.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "./node_modules/knip/schema.json"
+  "$schema": "./node_modules/knip/schema.json",
+  "entry": ["api/**/*.ts"]
 }

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -25,12 +25,12 @@ import type {
   WeeklyPerformanceResponse,
 } from "./types"
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000"
-
+// APIは同一オリジンの /api 配下で配信される（本番はVercel Function、開発はViteのプロキシが中継）。
+// そのため絶対URLは持たず、Cookieも同一オリジンのものだけを送る。
 async function fetchWithAuth<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+  const response = await fetch(endpoint, {
     ...options,
-    credentials: "include",
+    credentials: "same-origin",
     headers: {
       ...options.headers,
     },
@@ -63,7 +63,7 @@ async function sendJson<T>(endpoint: string, method: "POST" | "PUT", body: unkno
 
 // Auth APIs
 export async function login(username: string, password: string): Promise<TokenResponse> {
-  const response = await fetch(`${API_BASE_URL}/api/v1/token`, {
+  const response = await fetch("/api/v1/token", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -72,7 +72,7 @@ export async function login(username: string, password: string): Promise<TokenRe
       username,
       password,
     }),
-    credentials: "include",
+    credentials: "same-origin",
   })
 
   if (!response.ok) {

--- a/src/web/src/vite-env.d.ts
+++ b/src/web/src/vite-env.d.ts
@@ -1,9 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_API_URL: string
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv
-}

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -17,5 +17,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "api", "vite.config.ts"]
 }

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -2,11 +2,20 @@ import react from "@vitejs/plugin-react"
 import path from "path"
 import { defineConfig } from "vite"
 
+// 本番はVercel Function（api/[...path].ts）が /api を中継する。
+// 開発サーバでも同じ同一オリジン構成にするため、Viteのプロキシで同じ経路を再現する。
+const DEV_API_PROXY_TARGET = process.env.DEV_API_PROXY_TARGET ?? "http://localhost:8000"
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    proxy: {
+      "/api": DEV_API_PROXY_TARGET,
     },
   },
 })


### PR DESCRIPTION
## 背景

フロントがAPIを絶対URL（`VITE_API_URL`）で呼んでいたため、API側は `allow_credentials` 付きのCORSと `SameSite=None` のCookieを必要としていた。この構成には2つの弱点があった。

**1. プレビュー用の正規表現が広すぎる**

```python
allow_origin_regex=r"^https://.+-tomodo1773s-projects\.vercel\.app$"
```

Vercelアカウント配下の全プロジェクト・全プレビューデプロイを許可しており、信頼境界が「アカウントに乗るコード全部」まで広がっていた。

**2. `SameSite=None` によるCSRF**

CORSが防げるのは「レスポンスを読ませない」ことだけで、プリフライトが発生しない単純リクエストはサーバまで届いて実行される。ボディなしPOSTがこれに該当し、ログイン中に悪意あるページを開くだけで以下が外部から実行できた。

- `POST /api/v1/portfolio/update-and-notify`（履歴書き込み + LINE通知が発火）
- `POST /api/v1/holdings/recalculate-all`
- `POST /api/v1/holdings/{symbol}/recalculate`、`POST /api/v1/stock-splits/{symbol}/recalculate`

JSONボディを取る書き込み系はプリフライトで遮断されていた。

## 変更内容

フロントを同一オリジンの `/api` 配下に寄せ、クロスオリジン前提そのものを無くす。

| 環境 | 中継 | 転送先の指定 |
|------|------|-------------|
| 本番(Vercel) | Vercel Function `src/web/api/[...path].ts` | Vercelの環境変数 `API_ORIGIN` |
| ローカル | Vite開発サーバのプロキシ | `DEV_API_PROXY_TARGET`（既定 `http://localhost:8000`） |

転送先URLを環境変数から読むことで、公開リポジトリのコードと稼働中のバックエンドURLが直接結びつかないようにしている。プロキシは、FastAPIの末尾スラッシュ補正が返す絶対URLの `Location` を相対パスへ書き換え、ブラウザがバックエンドへ直接リダイレクトしないようにしている。

- **web**: `client.ts` から絶対URLを排除し `credentials` を `same-origin` に。`VITE_API_URL` は廃止
- **api**: CORSミドルウェアと `CORS_ORIGINS` 設定を全廃。Cookieを `SameSite=Lax` に統一（`Secure` は本番のみ、従来通り）
- **infra**: `cors_origins` 変数とCloud Runの `CORS_ORIGINS` 環境変数を削除
- **docs**: AGENTS.md に呼び出し経路の表を追加し、絶対URL/CORSを復活させないよう明記。README から `VITE_API_URL`・`CORS_ORIGINS` の記述を削除（存在しない `.env.local.example` への参照も解消）

## デプロイ手順

マージ前にVercel側で環境変数 **`API_ORIGIN`**（バックエンドのオリジン。パスは含めない）を設定してください。未設定の場合、プロキシは500と `API_ORIGIN が設定されていません` を返します。

Cloud Run側の `CORS_ORIGINS` は不要になりますが、残っていても無害です（OpenTofu適用時に削除されます）。

## 動作確認

- `pnpm check`（biome / tsc / knip）: 通過
- `pnpm test`: 184件通過
- `pnpm build`: 成功
- `uv run ruff format` / `uv run ruff check`: 通過
- `uv run pytest`: この環境ではDockerが使えずtestcontainersが起動しないため未実行（184件の収集と `stock.app` のimport、ミドルウェアが空になったことは確認済み）。実行はCIに委ねています

## 補足

ログインエンドポイントにレート制限が無い点は本PRのスコープ外としています（別PRで対応予定）。

---
_Generated by [Claude Code](https://claude.ai/code/session_018YBg8xDhk74ofgZc5DHBqt)_