### PR TITLE
fix(web): Workerがリダイレクトを跨いでボディを再送できるようにする

### DIFF
--- a/docs/adr/0003-frontend-hosting-cloudflare-workers.md
+++ b/docs/adr/0003-frontend-hosting-cloudflare-workers.md
@@ -72,4 +72,7 @@ URL map と serverless NEG で完全な同一オリジン化ができ、`infra/*
 - **`worker/` と `src/` は tsconfig を分ける必要がある。** `Request` / `Response` / `fetch` の型が Workers ランタイムと DOM で衝突する。`pnpm typecheck` は両方を検査する
 - **`worker-configuration.d.ts` はコミットしない。** 14000行超あるうえ、`wrangler types` がローカルの `.dev.vars` の変数名を読み取って `Env` に含めるため、マシン間で内容が一致しない。`pnpm typecheck` の先頭で毎回生成する（`prepare` は pnpm が "Already up to date" のときスキップするため使えなかった）
 - **Worker のプロキシはリダイレクトを追う必要がある。** FastAPI は末尾スラッシュ不一致で 307 を返し、その `Location` は絶対 URL（Host がバックエンドのもの）になる。ブラウザに渡すとクロスサイト遷移になって Cookie が送られず、かつバックエンドの URL が露出する。`redirect: "follow"` を明示すること（Workers の受信 Request は `redirect` が `manual` なので暗黙に引き継がれる）
+- **さらに、リダイレクトを追うにはボディをバッファで渡す必要がある。** 受信 Request のボディはストリームなので、リダイレクトで再送が必要になると `TypeError: A request with a one-time-use body ... encountered a redirect requiring the body to be retransmitted` になる。GET は影響しないため気づきにくく、ログインや CSV インポートのような POST だけが 500 になる
+- **`API_ORIGIN` は `https://` で登録する。** `http://` だと Cloud Run が HTTPS へリダイレクトし、上記のボディ再送エラーを踏む。GET は透過的に追従して成功するため原因が分かりにくい
+- **`API_ORIGIN` に同一ゾーン内のカスタムドメインを指定してはいけない。** Worker から自分と同じゾーンのホストへ `fetch` するとリダイレクトループになる（Cloudflare の既知の制約。回避策として案内される Service Bindings は Worker 間専用で、転送先が Cloud Run の本構成では使えない）。Worker の転送先は Cloud Run の `*.run.app` を直接指定する。API のカスタムドメインは Swagger UI や手動確認といった「人間が直接触る入口」として引き続き有効
 - Cookie の `samesite` 変更と CORS 撤去は、DNS を Vercel に戻すロールバック手段を残すため、切り替え検証が済んでから別途行う。それまで `vercel.json` と Vercel プロジェクトは残す

--- a/src/web/worker/index.ts
+++ b/src/web/worker/index.ts
@@ -12,19 +12,32 @@ interface Env {
   API_ORIGIN: string
 }
 
+/** ボディを持ちえないメソッド。これ以外はバッファに読み切ってから転送する */
+const BODYLESS_METHODS = new Set(["GET", "HEAD"])
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url)
-
-    // Host は fetch が転送先URLから導出する。Cloud Run は Host でルーティングするため、
-    // 元の Host を引き継いではいけない（Request構築時に Host は引き継がれない）
     const target = new URL(url.pathname + url.search, env.API_ORIGIN)
 
-    return fetch(new Request(target, request), {
-      // リダイレクトはWorker側で追う。FastAPIは末尾スラッシュ不一致で307を返し、
-      // その Location は絶対URL（Host がバックエンドのもの）になる。
-      // ブラウザに渡すとクロスサイト遷移になりCookieが送られず、
-      // かつバックエンドのURLが露出するため、ここで解決して最終結果だけを返す。
+    // Host は転送先URLから導出させる。Cloud Run は Host でルーティングするため、
+    // 元の Host（フロントのドメイン）を引き継ぐと転送先に届かない
+    const headers = new Headers(request.headers)
+    headers.delete("host")
+
+    // ボディはストリームのままだと「リダイレクトで再送が必要になったとき」に
+    // 例外になる（GETは影響しないが、ログインやCSVインポートのPOSTが落ちる）。
+    // 読み切ってバッファで渡すことでリダイレクトを跨げるようにする。
+    // 個人利用の範囲ではアップロードサイズが小さいため全読みで問題ない
+    const body = BODYLESS_METHODS.has(request.method) ? undefined : await request.arrayBuffer()
+
+    return fetch(target, {
+      method: request.method,
+      headers,
+      body,
+      // リダイレクトはWorker側で追い、ブラウザには最終結果だけを返す。
+      // ブラウザに3xxを渡すと Location が絶対URL（Host がバックエンドのもの）なので
+      // クロスサイト遷移になりCookieが送られず、かつバックエンドのURLが露出する。
       // Workersの受信Requestは redirect が manual なので明示的に上書きする
       redirect: "follow",
     })


### PR DESCRIPTION
## 症状

末尾スラッシュなしでボディ付きリクエストを送ると 500 になる。**現在の本番で再現します。**

```
POST /api/v1/stock-splits   -> 500          （FastAPIが307を返すパス）
POST /api/v1/stock-splits/  -> 401 JSON     （完全一致・リダイレクトなし）
```

## 原因

受信 Request のボディはストリームなので、転送先がリダイレクトを返すと再送できずに例外になる。

```
TypeError: A request with a one-time-use body (it was initialized from a stream,
not a buffer) encountered a redirect requiring the body to be retransmitted.
```

FastAPI は `redirect_slashes` が既定で有効なため、ルート定義と1文字違うパスに POST すると 307 が発生して踏む。**GET はボディがないので透過的に追従して成功する**ため気づきにくい。

## 修正

- ボディを `arrayBuffer()` で読み切ってから渡し、再送可能にする。GET / HEAD はボディを持たないので読まない
- あわせて `Host` を明示的に落とす。`fetch` が転送先URLから導出するのに任せたい箇所で、これまで `new Request(target, request)` の暗黙の挙動に依存していた

アップロードを全読みするが、個人利用の範囲（SBI証券のCSVエクスポート）ではサイズが小さいため問題ない。

## 検証

ローカル Worker から実 API（HTTPS でリダイレクトを返す）へ向けて確認。

| リクエスト | 修正前（本番） | 修正後 |
|---|---|---|
| `POST /api/v1/stock-splits` | 500 | **401 JSON** |
| `POST /api/v1/stock-splits/` | 401 JSON | 401 JSON |
| Worker の例外 | あり | **0件** |

いずれも認証なしなのでデータは作られません。

- `pnpm check`（Biome + tsc×2 + knip）exit 0
- `pnpm test` 184件 passed

## 経緯

Vercel から Cloudflare Workers への切り替え（#431）の作業中に踏んだ問題です。ADR 0003 の「注意する面」に、今回の件とあわせて次の2点も追記しました。どちらも切り替え時に実際に踏んだものです。

- **`API_ORIGIN` は `https://` で登録する。** `http://` だと Cloud Run が HTTPS へリダイレクトし、まさにこのボディ再送エラーを踏む
- **`API_ORIGIN` に同一ゾーン内のカスタムドメインを指定してはいけない。** Worker から自分と同じゾーンのホストへ `fetch` するとリダイレクトループになる（Cloudflare の既知の制約）。転送先は Cloud Run の `*.run.app` を直接指定する。API のカスタムドメインは Swagger UI や手動確認の入口として引き続き有効

🤖 Generated with [Claude Code](https://claude.com/claude-code)
