### PR TITLE
refactor: CORSを撤去しVercelの残骸を片付ける

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,6 @@ yarn-error.log*
 !.env.*.example
 !.env.*.sample
 
-# vercel（切り替え検証が済むまでロールバック手段として残す）
-.vercel/
-
 # cloudflare workers
 .wrangler/
 .dev.vars

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ uv run uvicorn stock.app:app --reload --port 8000
 
 - `src/docker-compose.yaml` のDBは `POSTGRES_PASSWORD=hogehoge` が固定です。DockerのDBを使う場合は
   `src/api/.env` の `DB_PASSWORD` を合わせるか、`src/docker-compose.yaml` を修正してください。
-- フロント開発サーバのオリジンに合わせて `CORS_ORIGINS` を設定してください（Vite既定は `http://localhost:5173`）。
+- CORSの設定は不要です。フロントは Vite の dev proxy（本番はCloudflare Worker）経由でAPIを叩くため、
+  ブラウザから見て常に同一オリジンになります。
 
 ### Frontend（`src/web`）
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ InvestLogixは、日本株・米国株の取引/保有/配当を記録し、ポ�
 - フロントエンド: Cloudflare Workers（Static Assets）
   - `/api/*` は Worker が Cloud Run へプロキシする。フロントとAPIを同一オリジンにすることで、認証Cookieがサードパーティ扱いにならずSafari等でも通る
   - バックエンドのオリジンは Worker の Secret（`API_ORIGIN`）に置くため、リポジトリにもクライアントバンドルにも現れない
-  - DNS切り替えのロールバック手段として、Vercelプロジェクトは切り替え検証が済むまで残している
 - バックエンド: Google Cloud Run
   - API は Cloud Run Service
   - 定時ジョブは Cloud Run Jobs ＋ Cloud Scheduler

--- a/docs/adr/0003-frontend-hosting-cloudflare-workers.md
+++ b/docs/adr/0003-frontend-hosting-cloudflare-workers.md
@@ -75,4 +75,5 @@ URL map と serverless NEG で完全な同一オリジン化ができ、`infra/*
 - **さらに、リダイレクトを追うにはボディをバッファで渡す必要がある。** 受信 Request のボディはストリームなので、リダイレクトで再送が必要になると `TypeError: A request with a one-time-use body ... encountered a redirect requiring the body to be retransmitted` になる。GET は影響しないため気づきにくく、ログインや CSV インポートのような POST だけが 500 になる
 - **`API_ORIGIN` は `https://` で登録する。** `http://` だと Cloud Run が HTTPS へリダイレクトし、上記のボディ再送エラーを踏む。GET は透過的に追従して成功するため原因が分かりにくい
 - **`API_ORIGIN` に同一ゾーン内のカスタムドメインを指定してはいけない。** Worker から自分と同じゾーンのホストへ `fetch` するとリダイレクトループになる（Cloudflare の既知の制約。回避策として案内される Service Bindings は Worker 間専用で、転送先が Cloud Run の本構成では使えない）。Worker の転送先は Cloud Run の `*.run.app` を直接指定する。API のカスタムドメインは Swagger UI や手動確認といった「人間が直接触る入口」として引き続き有効
-- Cookie の `samesite` 変更と CORS 撤去は、DNS を Vercel に戻すロールバック手段を残すため、切り替え検証が済んでから別途行う。それまで `vercel.json` と Vercel プロジェクトは残す
+- Cookie の `samesite` 変更と CORS 撤去は、DNS を Vercel に戻すロールバック手段を残すため、切り替え検証が済んでから別コミットで行った（PR #435）。**これを当てた時点で Vercel へのロールバックはできなくなる**（`samesite=lax` かつ CORS なしの API は `*.vercel.app` からのリクエストを通せない）。以降のロールバック手段は Worker の再デプロイのみ
+- API はどのオリジンからも CORS ヘッダーを返さなくなった。将来フロントを別オリジンに置く構成に戻すなら CORS ミドルウェアの再導入が必要になる

--- a/docs/adr/0003-frontend-hosting-cloudflare-workers.md
+++ b/docs/adr/0003-frontend-hosting-cloudflare-workers.md
@@ -77,3 +77,4 @@ URL map と serverless NEG で完全な同一オリジン化ができ、`infra/*
 - **`API_ORIGIN` に同一ゾーン内のカスタムドメインを指定してはいけない。** Worker から自分と同じゾーンのホストへ `fetch` するとリダイレクトループになる（Cloudflare の既知の制約。回避策として案内される Service Bindings は Worker 間専用で、転送先が Cloud Run の本構成では使えない）。Worker の転送先は Cloud Run の `*.run.app` を直接指定する。API のカスタムドメインは Swagger UI や手動確認といった「人間が直接触る入口」として引き続き有効
 - Cookie の `samesite` 変更と CORS 撤去は、DNS を Vercel に戻すロールバック手段を残すため、切り替え検証が済んでから別コミットで行った（PR #435）。**これを当てた時点で Vercel へのロールバックはできなくなる**（`samesite=lax` かつ CORS なしの API は `*.vercel.app` からのリクエストを通せない）。以降のロールバック手段は Worker の再デプロイのみ
 - API はどのオリジンからも CORS ヘッダーを返さなくなった。将来フロントを別オリジンに置く構成に戻すなら CORS ミドルウェアの再導入が必要になる
+- 同 PR で Vercel の残骸（`vercel.json`、Vercel の `projectId` / `orgId` を含む `project.json`、`@vercel/analytics`）も撤去した。アクセス解析の代替は入れていない

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -23,9 +23,6 @@ TF_VAR_image_uri="asia-northeast1-docker.pkg.dev/your-gcp-project-id/cloud-run-s
 TF_VAR_db_user="<DB_USER の値>"
 TF_VAR_db_host="<DB_HOST の値>"
 
-# CORS_ORIGINS（HCL 側で jsonencode するので、ここでは JSON 配列形式で渡す）
-TF_VAR_cors_origins='["https://example.com","http://localhost:5173"]'
-
 # CD (GitHub Actions) 用。WIF の attribute_condition で repository を絞るため必須。
 TF_VAR_github_repository="<github-owner>/<repo>"
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -35,7 +35,7 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
 ## 設計方針
 
 ### 公開リポジトリ向けの秘匿
-- プロジェクト ID・Supabase ホスト・CORS 用 URL 等の識別子は `variable` 化し、`infra/.env` に書いた `TF_VAR_*` を `set -a; source .env; set +a` で読み込んで注入する（`TF_VAR_*` は OpenTofu でもそのまま読まれる）。
+- プロジェクト ID・Supabase ホスト等の識別子は `variable` 化し、`infra/.env` に書いた `TF_VAR_*` を `set -a; source .env; set +a` で読み込んで注入する（`TF_VAR_*` は OpenTofu でもそのまま読まれる）。
 - Secret 値は Secret Manager に置き、`data "google_secret_manager_secret"` で参照のみ。state には機密値が乗らない（state 自体も非公開 GCS バケットに置く）。
 - state バックエンドのバケット名は `backend.hcl`（gitignore 対象）に書き、`tofu init -backend-config=backend.hcl` で渡す。`.tf` には書かない。
 

--- a/infra/cloud_run_service.tf
+++ b/infra/cloud_run_service.tf
@@ -55,10 +55,6 @@ resource "google_cloud_run_v2_service" "api" {
         name  = "DB_NAME"
         value = var.db_name
       }
-      env {
-        name  = "CORS_ORIGINS"
-        value = jsonencode(var.cors_origins)
-      }
 
       dynamic "env" {
         for_each = local.service_secrets

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -18,11 +18,6 @@ variable "db_host" {
   description = "Supabase の pooler ホスト。"
 }
 
-variable "cors_origins" {
-  type        = list(string)
-  description = "Cloud Run Service の CORS_ORIGINS に渡す URL リスト。"
-}
-
 variable "region" {
   type        = string
   default     = "asia-northeast1"

--- a/src/api/.env.sample
+++ b/src/api/.env.sample
@@ -26,5 +26,3 @@ OPENAI_API_KEY=your-openai-api-key  # 投資信託の通貨分類に使用
 # LINE settings
 LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token  # LINE Messaging APIのチャネルアクセストークン
 
-# CORS settings
-CORS_ORIGINS=["http://localhost:3000"]  # フロントエンドのオリジンに合わせて設定してください

--- a/src/api/.env.sample
+++ b/src/api/.env.sample
@@ -25,4 +25,3 @@ OPENAI_API_KEY=your-openai-api-key  # 投資信託の通貨分類に使用
 
 # LINE settings
 LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token  # LINE Messaging APIのチャネルアクセストークン
-

--- a/src/api/stock/app.py
+++ b/src/api/stock/app.py
@@ -4,10 +4,8 @@ FastAPIアプリケーション定義
 """
 
 from fastapi import FastAPI, Request, status
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from .database import settings
 from .routes import (
     auth,
     dividends,
@@ -28,15 +26,8 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORSミドルウェアの設定
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS,
-    allow_origin_regex=r"^https://.+-tomodo1773s-projects\.vercel\.app$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# CORSミドルウェアは持たない。ブラウザからのアクセスはCloudflare Worker経由の
+# 同一オリジンリクエストになり、/docs もAPI自身が同一オリジンで配信するため不要。
 
 
 # ドメインエラーからHTTPレスポンスへの変換をここに集約する。

--- a/src/api/stock/database.py
+++ b/src/api/stock/database.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 
 from pydantic import field_validator
@@ -51,9 +50,6 @@ class Settings(BaseSettings):
     # OpenAI API設定
     OPENAI_API_KEY: str = ""
 
-    # CORS設定
-    CORS_ORIGINS: list[str] = ["http://localhost:3000"]
-
     # サーバー設定
     HOST: str = "0.0.0.0"
     PORT: int = 8000
@@ -67,17 +63,6 @@ class Settings(BaseSettings):
         if self.DATABASE_URL:
             return self.DATABASE_URL
         return f"postgresql+asyncpg://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
-
-    @field_validator("CORS_ORIGINS", mode="before")
-    @classmethod
-    def parse_cors_origins(cls, v: str | list[str]) -> list[str]:
-        """CORS_ORIGINSをJSON文字列からリストに変換"""
-        if isinstance(v, str):
-            try:
-                return json.loads(v)
-            except json.JSONDecodeError:
-                return [i.strip() for i in v.split(",")]
-        return v
 
     @field_validator("PORT", "ACCESS_TOKEN_EXPIRE_MINUTES", mode="before")
     @classmethod

--- a/src/api/stock/routes/auth.py
+++ b/src/api/stock/routes/auth.py
@@ -37,14 +37,15 @@ async def login_for_access_token(
 
     access_token = create_access_token(data={"sub": user.username})
 
-    # 環境に応じてCookie設定を変更
-    is_production = ENVIRONMENT.lower() == "production"
+    # フロントとAPIは同一オリジン（Cloudflare Workerが /api/* を転送する）なので
+    # このCookieはサードパーティCookieにならない。よって samesite=lax で足りる。
+    # Secure だけは本番のみ有効にする（ローカルはhttpで開発するため）
     response.set_cookie(
         key="token",
         value=access_token,
         httponly=True,
-        secure=is_production,
-        samesite="none" if is_production else "lax",
+        secure=ENVIRONMENT.lower() == "production",
+        samesite="lax",
         max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # 分を秒に変換
         path="/",
     )

--- a/src/web/.gitignore
+++ b/src/web/.gitignore
@@ -12,9 +12,6 @@ build
 # local env files
 .env*.local
 
-# vercel（切り替え検証が済むまでロールバック手段として残す）
-.vercel
-
 # cloudflare workers
 .wrangler
 # wrangler dev 用のローカル環境変数（API_ORIGIN が入るため絶対にコミットしない）

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -23,7 +23,6 @@
     "@radix-ui/react-label": "^2.1.15",
     "@radix-ui/react-slot": "1.3.3",
     "@radix-ui/react-tooltip": "^1.2.16",
-    "@vercel/analytics": "2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "immer": "latest",

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.16
         version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@vercel/analytics':
-        specifier: 2.0.1
-        version: 2.0.1(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1979,35 +1976,6 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  '@vercel/analytics@2.0.1':
-    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      nuxt: '>= 3'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      nuxt:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -4428,10 +4396,6 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
-
-  '@vercel/analytics@2.0.1(react@19.2.8)':
-    optionalDependencies:
-      react: 19.2.8
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:

--- a/src/web/project.json
+++ b/src/web/project.json
@@ -1,5 +1,0 @@
-{
-  "projectId": "prj_LJHjxJqHgRr5JtPQVKyIzyRh1hQy",
-  "orgId": "team_VANaI5cnDaUxzBf4TMJXklHc",
-  "projectName": "investlogix-web"
-}

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -27,11 +27,11 @@ import type {
 
 // APIは常に同一オリジンの相対パスで叩く。本番はCloudflare Workerが、
 // 開発時はViteのdev proxyが /api/* をバックエンドへ転送する。
-// バックエンドのURLをバンドルに焼き込まないための設計
+// バックエンドのURLをバンドルに焼き込まないための設計。
+// 同一オリジンなので認証Cookieは既定で送られる（credentials の指定は不要）
 async function fetchWithAuth<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(endpoint, {
     ...options,
-    credentials: "include",
     headers: {
       ...options.headers,
     },
@@ -73,7 +73,6 @@ export async function login(username: string, password: string): Promise<TokenRe
       username,
       password,
     }),
-    credentials: "include",
   })
 
   if (!response.ok) {

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -1,11 +1,8 @@
-import { inject } from "@vercel/analytics"
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { BrowserRouter } from "react-router"
 import App from "./App"
 import "./index.css"
-
-inject()
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/web/vercel.json
+++ b/src/web/vercel.json
@@ -1,3 +1,0 @@
-{
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
-}

--- a/src/web/wrangler.jsonc
+++ b/src/web/wrangler.jsonc
@@ -16,7 +16,7 @@
   "compatibility_date": "2026-07-29",
   "assets": {
     "directory": "./dist",
-    // 現在の vercel.json の rewrite と等価。SPAのルートを index.html に落とす
+    // SPAのルートを index.html に落とす（クライアントルーティングを直リロードでも通す）
     "not_found_handling": "single-page-application",
     // /api/* だけ Worker に渡す。それ以外はWorkerを起動せずアセット配信されるので
     // Worker のリクエスト課金対象にならない


### PR DESCRIPTION
Cloudflare Workers 移行（#431, #434）の後片付け。Phase 3（API を締める）と Phase 4（Vercel 残骸の撤去）をまとめている。本番のカスタムドメインでログインが安定して動いていることを前提とする。

コミットは2つに分けてある。

## Phase 3 — CORS 撤去と SameSite=Lax 化 (`7630278`)

`/api/*` が同一オリジンになったので、サードパーティ Cookie を成立させるために必要だった設定を撤去する。

| ファイル | 変更 |
|---|---|
| `stock/routes/auth.py` | Cookie の `samesite` を `"none" if is_production else "lax"` → `"lax"` 固定。`secure` は本番のみ True を維持 |
| `stock/app.py` | `CORSMiddleware` ブロックと import を削除。未使用になった `from .database import settings` も削除 |
| `stock/database.py` | `CORS_ORIGINS` 設定と `parse_cors_origins` バリデータ、未使用になった `import json` を削除 |
| `infra/variables.tf` / `cloud_run_service.tf` | `cors_origins` 変数と Cloud Run の `CORS_ORIGINS` env を削除 |
| `src/web/src/lib/api/client.ts` | 同一オリジンでは既定で Cookie が送られるため `credentials: "include"` を削除 |
| README ×2 / `.env.example` / `.env.sample` | CORS 設定の記述を削除 |

`app.py` にハードコードされていた `allow_origin_regex=r"^https://.+-tomodo1773s-projects\.vercel\.app$"`（Vercel の組織名）もこれで消える。

CORS 撤去の安全性:
- CORS を検証しているテストは存在しない
- API は Cloud Run 上で自身の `/docs` を同一オリジンで提供するため Swagger UI に影響しない
- LINE 通知は送信のみでブラウザを経由しない

## Phase 4 — Vercel 残骸の撤去 (`0e133d8`)

- `vercel.json` を削除（SPA フォールバックは `wrangler.jsonc` の `not_found_handling` が担っている）
- `project.json` を削除。**Vercel の `projectId` / `orgId` が公開リポジトリにコミットされていた**
- `@vercel/analytics` と `main.tsx` の `inject()` を削除。アクセス解析の代替は入れない
- 両 `.gitignore` の `.vercel` エントリを削除
- `wrangler.jsonc` に残っていた「`vercel.json` の rewrite と等価」というコメントを、消えるファイルへの参照でなくなるよう書き換え

## ロールバックについて

**この PR を当てた時点で Vercel へのロールバックはできなくなる。** `samesite=lax` かつ CORS なしの API は `*.vercel.app` からのリクエストを通せない。Phase 2（カスタムドメインでのログイン成功）は確認済みなので前提を満たしている。以降のロールバック手段は Worker の再デプロイのみ。ADR 0003 の「注意する面」にこの点を追記した。

## 検証

- `uv run ruff format` / `uv run ruff check` — クリーン
- `uv run pytest` — **184 passed**（設定削除による `ImportError` / `AttributeError` / `NameError` なし）
- `src/web`: `pnpm check` exit 0、`pnpm test` **184 passed**、`pnpm build` 成功
- `wrangler deploy --dry-run` 成功
- リポジトリ全体 grep: `CORS_ORIGINS` / `CORSMiddleware` / `cors_origins` / `vercel` の残存参照は ADR 0003 の経緯説明のみ
- ビルド成果物 (`dist/assets/*.js`) 内の `vercel` 出現回数 **0**
- `pnpm-lock.yaml` 内の `@vercel` 出現回数 **0**

## マージ後に必要な手動作業

1. 手元の `infra/.env` から `TF_VAR_cors_origins` を削除して `tofu apply`（Cloud Run から `CORS_ORIGINS` env が外れる）
2. 手元の `src/api/.env` の `CORS_ORIGINS` 行は削除して差し支えない（`extra="allow"` のため残っていてもエラーにはならない）
3. Vercel プロジェクト自体の削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)