### PR TITLE
fix: ログアウト時にサーバー側で認証Cookieを削除する

### DIFF
--- a/src/api/stock/routes/auth.py
+++ b/src/api/stock/routes/auth.py
@@ -9,6 +9,21 @@ from ..services.auth_service import AuthService
 
 router = APIRouter()
 
+TOKEN_COOKIE_NAME = "token"
+
+# フロントとAPIは同一オリジン（Cloudflare Workerが /api/* を転送する）なので
+# このCookieはサードパーティCookieにならない。よって samesite=lax で足りる。
+# Secure だけは本番のみ有効にする（ローカルはhttpで開発するため）
+#
+# 削除時に発行と同じ属性を渡さないとブラウザ側でCookieが消えないことがあるため、
+# 発行(set_cookie)と削除(delete_cookie)で属性を共有する。
+TOKEN_COOKIE_ATTRS = {
+    "path": "/",
+    "httponly": True,
+    "secure": settings.ENVIRONMENT.lower() == "production",
+    "samesite": "lax",
+}
+
 
 @router.post("/token", response_model=Token)
 async def login_for_access_token(
@@ -30,20 +45,25 @@ async def login_for_access_token(
 
     access_token = create_access_token(data={"sub": user.username})
 
-    # フロントとAPIは同一オリジン（Cloudflare Workerが /api/* を転送する）なので
-    # このCookieはサードパーティCookieにならない。よって samesite=lax で足りる。
-    # Secure だけは本番のみ有効にする（ローカルはhttpで開発するため）
     response.set_cookie(
-        key="token",
+        key=TOKEN_COOKIE_NAME,
         value=access_token,
-        httponly=True,
-        secure=settings.ENVIRONMENT.lower() == "production",
-        samesite="lax",
         max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # 分を秒に変換
-        path="/",
+        **TOKEN_COOKIE_ATTRS,
     )
     logger.info("Authトークンを発行しました action=create user_id={}", user.user_id)
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(response: Response):
+    """
+    ログアウトする
+    - 認証Cookieを削除する
+    - 認証は不要（Cookieを消すだけの操作なので、未認証で叩かれても無害）
+    """
+    response.delete_cookie(key=TOKEN_COOKIE_NAME, **TOKEN_COOKIE_ATTRS)
+    logger.info("Authトークンを削除しました action=delete")
 
 
 @router.post("/users/", response_model=User)

--- a/src/api/tests/auth/test_auth.py
+++ b/src/api/tests/auth/test_auth.py
@@ -124,6 +124,38 @@ async def test_login(client: AsyncClient, db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_logout(client: AsyncClient, auth_token: None):
+    """ログアウトのテスト
+
+    期待する動作:
+    - ステータスコード204
+    - Set-Cookieでtokenが失効する（発行時と同じ path / samesite 属性が付く）
+    - ログアウト後は認証が必要なエンドポイントが401になる
+
+    Args:
+        client: 非同期HTTPクライアント
+        auth_token: 一般ユーザーの認証フィクスチャ（clientにCookieをセットする副作用）
+    """
+    # ログアウト前はCookie認証が通ることを確認
+    assert (await client.get("/api/v1/me")).status_code == 200
+
+    response = await client.post("/api/v1/logout")
+
+    # レスポンス検証
+    assert response.status_code == 204
+    set_cookie = response.headers["set-cookie"]
+    assert "token=" in set_cookie
+    assert "Max-Age=0" in set_cookie
+    # 発行時と属性が食い違うとブラウザ側で削除が効かないため、set_cookieと揃っていることを確認
+    assert "Path=/" in set_cookie
+    assert "SameSite=lax" in set_cookie
+
+    # Cookieが破棄され、セッションが終了していることを確認
+    assert "token" not in client.cookies
+    assert (await client.get("/api/v1/me")).status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_login_invalid_credentials(client: AsyncClient):
     """無効な認証情報でのログインテスト
 

--- a/src/web/src/components/layout/app-layout.tsx
+++ b/src/web/src/components/layout/app-layout.tsx
@@ -1,5 +1,5 @@
 import { LogOut } from "lucide-react"
-import type { ReactNode } from "react"
+import { type ReactNode, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { logout as logoutApi } from "@/lib/api/client"
 import { useAuthStore } from "@/lib/stores/auth-store"
@@ -12,12 +12,15 @@ interface AppLayoutProps {
 
 export function AppLayout({ children }: AppLayoutProps) {
   const { user, logout } = useAuthStore()
+  // 遷移は必ず起きるので解除は不要。連打防止と「処理中」の表示のためだけに持つ
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   const handleLogout = async () => {
+    setIsLoggingOut(true)
     try {
       await logoutApi()
     } catch {
-      // サーバー側のCookie削除に失敗しても、クライアント状態のリセットと遷移は行う
+      // サーバー側のCookie削除に失敗・タイムアウトしても、クライアント状態のリセットと遷移は行う
       // （APIが落ちていてもUIが固まらないようにする）
     }
     logout()
@@ -42,8 +45,8 @@ export function AppLayout({ children }: AppLayoutProps) {
             </div>
             <div className="flex items-center gap-3">
               {user && <span className="text-sm text-muted-foreground">{user.username}</span>}
-              <Button variant="ghost" size="icon" onClick={handleLogout}>
-                <LogOut className="h-4 w-4" />
+              <Button variant="ghost" size="icon" onClick={handleLogout} disabled={isLoggingOut}>
+                <LogOut className={`h-4 w-4 ${isLoggingOut ? "animate-spin" : ""}`} />
               </Button>
             </div>
           </div>

--- a/src/web/src/components/layout/app-layout.tsx
+++ b/src/web/src/components/layout/app-layout.tsx
@@ -1,6 +1,7 @@
 import { LogOut } from "lucide-react"
 import type { ReactNode } from "react"
 import { Button } from "@/components/ui/button"
+import { logout as logoutApi } from "@/lib/api/client"
 import { useAuthStore } from "@/lib/stores/auth-store"
 import { MobileNav } from "./mobile-nav"
 import { Sidebar } from "./sidebar"
@@ -12,7 +13,13 @@ interface AppLayoutProps {
 export function AppLayout({ children }: AppLayoutProps) {
   const { user, logout } = useAuthStore()
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      await logoutApi()
+    } catch {
+      // サーバー側のCookie削除に失敗しても、クライアント状態のリセットと遷移は行う
+      // （APIが落ちていてもUIが固まらないようにする）
+    }
     logout()
     window.location.href = "/login"
   }

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -83,6 +83,16 @@ export async function login(username: string, password: string): Promise<TokenRe
   return response.json()
 }
 
+// 認証Cookieはhttponlyなのでクライアントからは消せない。サーバーに削除させる。
+// 204を返すのでボディのパースは行わない（fetchWithAuthは使えない）
+export async function logout(): Promise<void> {
+  const response = await fetch("/api/v1/logout", { method: "POST" })
+
+  if (!response.ok) {
+    throw new Error("Logout failed")
+  }
+}
+
 export async function getCurrentUser(): Promise<User> {
   return fetchWithAuth<User>("/api/v1/me")
 }

--- a/src/web/src/lib/api/client.ts
+++ b/src/web/src/lib/api/client.ts
@@ -83,10 +83,18 @@ export async function login(username: string, password: string): Promise<TokenRe
   return response.json()
 }
 
+// 応答が返らないまま固まるとログアウト処理全体が止まってしまうため、待ち時間に上限を設ける。
+// Cloud Runのコールドスタート（数秒かかることがある）を空振りさせない程度には長く取る。
+// タイムアウトすると fetch は AbortError で reject するので、呼び出し側のcatchに落ちる
+const LOGOUT_TIMEOUT_MS = 10_000
+
 // 認証Cookieはhttponlyなのでクライアントからは消せない。サーバーに削除させる。
 // 204を返すのでボディのパースは行わない（fetchWithAuthは使えない）
 export async function logout(): Promise<void> {
-  const response = await fetch("/api/v1/logout", { method: "POST" })
+  const response = await fetch("/api/v1/logout", {
+    method: "POST",
+    signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
+  })
 
   if (!response.ok) {
     throw new Error("Logout failed")


### PR DESCRIPTION
Closes #436

ログアウトしてもセッションが終わらない不具合の修正。コミットは2つに分けてある。

## 何が起きていたか

認証Cookieは `httponly` なのでJavaScriptからは消せない。にもかかわらずログアウトは画面側の状態フラグを落とすだけで、サーバーには何も伝えていなかった。

結果、ログアウト後にリロードすると `AuthProvider` の起動時チェックが残った Cookie を送り、`/api/v1/me` が200を返して `isAuthenticated` が復活する。ログイン画面から任意のルートへ移動すれば資格情報なしで入れてしまい、これがCookieの有効期限（30分）続く。共有端末では実害がある。

API側にはログアウトの受け口自体が存在しなかった。

## 1. サーバー側でCookieを削除する (`3b81cd9`)

| ファイル | 変更 |
|---|---|
| `stock/routes/auth.py` | `POST /api/v1/logout`（204）を追加。`delete_cookie` で `token` を失効させる |
| `stock/routes/auth.py` | Cookie属性を `TOKEN_COOKIE_ATTRS` に切り出し、発行と削除で共有 |
| `src/web/src/lib/api/client.ts` | `logout()` を追加 |
| `src/web/src/components/layout/app-layout.tsx` | ログアウト操作からAPIを呼んでから遷移する |
| `tests/auth/test_auth.py` | `test_logout` を追加 |

### 認証を required にしていない理由

やることは「Cookieを捨てろ」という指示だけなので、未認証で叩かれても無害。逆に認証必須にすると、期限切れ間際やセッションが壊れかけた状態でログアウトできなくなる。**一番消したい状況で消せない**という本末転倒になるため、あえて不要にしている（issueの修正方針どおり）。

### 属性を共有した理由

Cookieには「削除」という操作が存在せず、**同じ区画に期限切れのCookieを上書き発行する**ことでしか消せない。ブラウザは名前だけでなく `path` なども込みで区画を管理しているため、発行時と削除時で属性が一文字でもズレると「別の区画の話」と解釈され、狙ったCookieは無傷のまま残る。しかもエラーは一切出ない（サーバーログは成功、ブラウザ上は何も起きない）。

削除側に属性を書き写す対応は、将来どちらか片方だけが変更されたときに必ず壊れるので採らなかった。発行と削除が同じ定義を参照する形にして、片方だけズレる事故が起こりえないようにしている。

### テスト

正常系1本だが、因果の全体が通ることを確認している。

「ログアウト前は `/api/v1/me` が200」→「204が返る」→「`Set-Cookie` に `Max-Age=0` / `Path=/` / `SameSite=lax`」→「Cookieがjarから消えている」→「`/api/v1/me` が401」

最後の一歩があることで、報告された症状そのものが再現しなくなったことを保証できる。属性がズレていればCookieが残るので途中で落ちる。

## 2. 応答待ちに上限を設ける (`184c1f1`)

1をレビューして見つけた穴。

`fetch` はサーバーが接続を受けたまま応答を返さない場合、resolveもrejectもしない。この状態だと `catch` に落ちず、後続の状態リセットと遷移が実行されない。つまり**ログアウトボタンが無反応のまま認証済み画面に留まる**——issueが問題にしていた状況が別ルートで再現する。

- ログアウトの `fetch` に `AbortSignal.timeout` を付け、ハング時も必ず `catch` へ落ちるようにした
- 上限は10秒。短くするとコールドスタート（放置したタブからのログアウトでバックエンドが立ち上がり直す場合、数秒かかる）で**本来成功するリクエストを自分から打ち切ってしまい**、Cookieが消えず元のバグに戻る。実際に効くのは異常時だけなので安全側に倒した
- 待機中はボタンを無効化しスピナーを出す（連打防止と、無反応に見えるのを防ぐため）。遷移で必ず終わる処理なので解除は入れていない

なお、先に遷移してリクエストを投げっぱなしにする直し方は取れない。`window.location.href` による遷移がリクエストの送信自体を中断しうるため、Cookieが消えない可能性が出る。待つこと自体は正しく、上限をつけるのが筋という判断。

## #440 との衝突について

`refactor(api): 設定読み込みをpydantic Settingsに統一する` (#440) が先にmainへ入り、`auth.py` の同じ箇所（`ENVIRONMENT` の読み取り）を書き換えていたためコンフリクトした。**#440 の上にrebaseして解消済み**で、マージコミットは作っていない。

解消内容は、`TOKEN_COOKIE_ATTRS` の `secure` を `settings.ENVIRONMENT` 参照に合わせただけ。#440 が導入した「設定はSettingsに集約する」方針と、TID251（`os.getenv` 等の禁止）にも従っている。

なお、gitの自動マージは `secure=ENVIRONMENT.lower() == ...` の行を**コンフリクトマーカーなしでそのまま残した**（削除された側の定義を参照する未定義名になる）ため、マーカーの箇所だけでなくファイル全体を確認して直している。rebase後に全テストを再実行して確認済み。

## レビュー時に見てほしい点

- 10秒という上限値。コールドスタートの実測と合っているか
- ログアウトの受け口を未認証で開けている点。強制ログアウトを仕掛けられる（CSRF）が、影響は嫌がらせ止まりでセッションの奪取にはつながらないため、この規模では許容と判断している

## 検証

rebase後に再実行した結果。

- API: `tests/auth/` + `tests/api/` 110件すべてpass（api-test-runner経由 / `TC_HOST=127.0.0.1`）
- API: `uv run ruff check .` / `ruff format --check .` — クリーン（TID251含む）
- Web: `pnpm check` exit 0、`pnpm test` 184件pass

フロント側のテストは追加していない。`handleLogout` の検証には fetch と `window.location` の両方をモックする必要があり、確かめられるのは「呼んだかどうか」だけでCookieが消えたかは分からない。モックの手間に対して得られる確信が薄いため、プロジェクトのテスト方針（モック中心のテストは見送る）に従った。挙動の本体はAPIテストでカバーしている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
