### PR TITLE
fix(web): 未知のパスで画面が真っ白になるのを直す

### DIFF
--- a/src/web/public/site.webmanifest
+++ b/src/web/public/site.webmanifest
@@ -1,6 +1,7 @@
 {
   "name": "InvestLogix - Portfolio Manager",
   "short_name": "InvestLogix",
+  "start_url": "/",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router"
+import { Navigate, Route, Routes } from "react-router"
 import { AuthenticatedLayout } from "@/components/layout/authenticated-layout"
 import Dividends from "./routes/Dividends"
 import HoldingDetail from "./routes/HoldingDetail"
@@ -25,6 +25,9 @@ function App() {
         <Route path="/stock-splits" element={<StockSplits />} />
         <Route path="/stocks" element={<Stocks />} />
       </Route>
+      {/* 一致するルートが無いと何も描画されず真っ白になる。廃止した /login のブックマークや
+          PWAのstart_urlが残っていても復帰できるよう、トップへ寄せる */}
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )
 }


### PR DESCRIPTION
#443 のリグレッション。スマホのPWAからAccessログイン後に画面が真っ白になる。

## 原因

`/login` ルートを廃止したときに catch-all を置かなかった。react-router は一致するルートが無いと何も描画しないため、`/login` を開くと真っ白になる。

`site.webmanifest` に `start_url` が無く、PWA は仕様上インストール時に開いていたページのURLを start_url として使う。旧アプリは未認証時に `/login` へ遷移していたため、その状態でホーム画面に追加していると `/login` から起動して何も表示されない。

Cloudflare Access のログインはエッジで完結するので成功し、その後 `/login` に戻ってきて真っ白、という順序になる。

## 修正

- 一致しないパスはトップへリダイレクトする
- `start_url` を `/` に明示し、以後インストール時のURLに依存しないようにする

catch-all はもともと無かったので、`/login` 以外の未知のパスでも同じことが起きていた。今回まとめて塞ぐ。

## 確認

`pnpm check` 通過 / 182 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)