### PR TITLE
feat(mcp): Cloudflare Access対応MCPサーバーを追加

### DIFF
--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
 
 env:
+  # IMAGE は常に ":sha" が付くため空にならない。未設定の検出には IMAGE_BASE を見る
+  IMAGE_BASE: ${{ vars.IMAGE_BASE }}
   IMAGE: ${{ vars.IMAGE_BASE }}:${{ github.sha }}
   REGION: ${{ vars.GCP_REGION }}
   SERVICE: ${{ vars.SERVICE_NAME }}
@@ -26,6 +28,20 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
+
+      # 変数はGitHub側に手動登録するため、抜けたまま走ると gcloud が空の名前を受け取り、
+      # デプロイの途中でステップが落ちる（Serviceだけ新イメージ、Jobsは旧イメージのまま）。
+      # ビルド前にまとめて確認して、部分適用を起こさずに止める
+      - name: Check required variables
+        run: |
+          missing=""
+          for name in IMAGE_BASE REGION SERVICE MCP_SERVICE; do
+            [ -n "${!name}" ] || missing="$missing $name"
+          done
+          if [ -n "$missing" ]; then
+            echo "リポジトリ変数が未設定です:$missing (infra/README.md を参照)" >&2
+            exit 1
+          fi
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/api-cd.yml
+++ b/.github/workflows/api-cd.yml
@@ -15,6 +15,7 @@ env:
   IMAGE: ${{ vars.IMAGE_BASE }}:${{ github.sha }}
   REGION: ${{ vars.GCP_REGION }}
   SERVICE: ${{ vars.SERVICE_NAME }}
+  MCP_SERVICE: ${{ vars.MCP_SERVICE_NAME }}
   # infra/locals.tf の jobs map と同期させること
   JOBS: "recalc-holdings update-and-notify"
 
@@ -43,6 +44,7 @@ jobs:
       - name: Deploy Cloud Run Service & Jobs
         run: |
           gcloud run deploy "$SERVICE" --image="$IMAGE" --region="$REGION" --quiet
+          gcloud run deploy "$MCP_SERVICE" --image="$IMAGE" --region="$REGION" --quiet
           for job in $JOBS; do
             gcloud run jobs update "$job" --image="$IMAGE" --region="$REGION" --quiet
           done
@@ -62,6 +64,7 @@ jobs:
             fi
           }
           check services "$SERVICE" "spec.template.spec.containers[0].image"
+          check services "$MCP_SERVICE" "spec.template.spec.containers[0].image"
           for job in $JOBS; do
             check jobs "$job" "spec.template.spec.template.spec.containers[0].image"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 __pycache__
 .secrets
 
+# 一時作業メモ。本番のドメイン名・プロジェクトIDなど公開リポジトリに出せない
+# 識別子を書くことがあるため、手元専用にしてコミットさせない
+docs/tmp-*
+
 # Python packaging
 *.egg-info/
 *.egg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Ruffのバージョンは `src/api/uv.lock` を唯一の情報源とします。
 
 React + Vite ベースのSPAです。Cloudflare Workers（Static Assets）でデプロイされています。
 
-`worker/index.ts` が `/api/*` を受けて Cloud Run へプロキシします。これによりフロントとAPIが同一オリジンになるため、フロント側はAPIを**常に相対パスで叩きます**（`API_BASE_URL` のような基底URLは持ちません）。バックエンドのオリジンは Worker の Secret（`API_ORIGIN`）にあり、リポジトリにもクライアントバンドルにも入れません。
+`worker/index.ts` が `/api/*` と `/mcp` を、それぞれAPI/MCP用Cloud Runへプロキシします。フロント側はAPIを**常に相対パスで叩きます**（`API_BASE_URL` のような基底URLは持ちません）。オリジンは Worker の Secret（`API_ORIGIN` / `MCP_ORIGIN`）にあり、リポジトリにもクライアントバンドルにも入れません。
 
 - Workersランタイムの型 `worker-configuration.d.ts` は生成物なのでコミットしない（gitignore済み）。14000行超あるうえ、`wrangler types` がローカルの `.dev.vars` の変数名を取り込むためマシン間で内容が一致しない。`pnpm typecheck` が毎回先頭で生成するので、手動実行は不要（単体で回したいときは `pnpm cf-typegen`）
 - `compatibility_date` は同梱 workerd がサポートする上限日以下にする。超えると `wrangler dev` が起動しない。制約は一方向（wrangler を上げると上限が上がるだけ）なので、**依存更新に追随して上げる必要はない**。日付でゲートされた挙動が欲しいときだけ意図して上げる
@@ -176,6 +176,9 @@ FastAPIベースのREST APIです。PostgreSQLをデータベースとして使�
 # 開発サーバ起動
 uv run uvicorn stock.app:app --reload --port 8000
 
+# MCPサーバ起動（Streamable HTTP: http://localhost:8001/mcp）
+uv run uvicorn stock.mcp.app:app --reload --port 8001
+
 # 依存関係のインストール（Socket Firewall経由）
 sfw uv sync
 
@@ -202,13 +205,15 @@ uv run alembic downgrade -1
 
 本人確認とログインセッションは **Cloudflare Access** に委譲する。アプリはパスワードも独自トークンも持たない。判断の経緯は `docs/adr/0004-cloudflare-access-authentication.md`。
 
-処理の流れは3層に分かれる。
+処理の流れはフレームワーク非依存の中核と、REST/MCP固有の入口に分かれる。
 
 | ファイル | 責務 |
 |---------|------|
 | `stock/cloudflare_access.py` | `Cf-Access-Jwt-Assertion` の検証（JWKS取得・署名・issuer・audience・有効期限）。DBにもFastAPIにも依存しない |
 | `stock/services/user_service.py` | 検証済みの外部ID (`issuer`, `sub`) からアプリ内 `users` を解決する。未紐付けのユーザーはAccessが確認済みのメールアドレスで初回だけ紐付ける |
-| `stock/auth.py` | FastAPIの依存性。上2つを繋ぎ、RLS用の `app.current_user_id` を設定する |
+| `stock/user_context.py` | User解決とRLS設定を同じDBセッションへ束縛する。REST/MCP共通 |
+| `stock/auth.py` | FastAPIの依存性として共通コンテキストを接続する |
+| `stock/mcp/` | MCP全体へ認証を強制し、RLS済みコンテキストからService層を呼ぶ |
 
 - 認証は `FastAPI(dependencies=[Depends(get_access_identity)])` でアプリ全体に掛ける。ルート単位で書き忘れても素通りしない
 - Cloud Run の `*.run.app` は公開されたままなので、この検証がCloudflareを迂回した直アクセスの防波堤になる
@@ -216,6 +221,7 @@ uv run alembic downgrade -1
 - Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
 - `is_admin`、データ所有権、PostgreSQL RLS はアプリ側の責務。Accessのメールアドレスやグループを検証なしに権限へ変換しない
 - 定期ジョブはGoogle Cloud Run JobsでDB直結のため、HTTP経由のAPI認証経路は持たない
+- MCPは公式Python SDKのStreamable HTTPを使い、APIとは別のCloud Runサービスで動かす。公開ツールは参照系から始める
 
 ローカル開発とテストでの差し替えは以下。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ uv run alembic downgrade -1
 | ファイル | 責務 |
 |---------|------|
 | `stock/cloudflare_access.py` | `Cf-Access-Jwt-Assertion` の検証（JWKS取得・署名・issuer・audience・有効期限）。DBにもFastAPIにも依存しない |
-| `stock/services/user_service.py` | 検証済みの外部ID (`issuer`, `sub`) からアプリ内 `users` を解決する。未紐付けのユーザーはAccessが確認済みのメールアドレスで初回だけ紐付ける |
+| `stock/services/user_service.py` | Accessが確認済みのメールアドレスからアプリ内 `users` を解決する。JWTの `sub` はAccess applicationごとに変わりうるため紐付けキーにしない |
 | `stock/user_context.py` | User解決とRLS設定を同じDBセッションへ束縛する。REST/MCP共通 |
 | `stock/auth.py` | FastAPIの依存性として共通コンテキストを接続する |
 | `stock/mcp/` | MCP全体へ認証を強制し、RLS済みコンテキストからService層を呼ぶ |
@@ -218,7 +218,7 @@ uv run alembic downgrade -1
 - 認証は `FastAPI(dependencies=[Depends(get_access_identity)])` でアプリ全体に掛ける。ルート単位で書き忘れても素通りしない
 - Cloud Run の `*.run.app` は公開されたままなので、この検証がCloudflareを迂回した直アクセスの防波堤になる
 - 未認証は401、Access認証済みだがアプリ未登録は403
-- Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
+- Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` と `/mcp` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
 - `is_admin`、データ所有権、PostgreSQL RLS はアプリ側の責務。Accessのメールアドレスやグループを検証なしに権限へ変換しない
 - 定期ジョブはGoogle Cloud Run JobsでDB直結のため、HTTP経由のAPI認証経路は持たない
 - MCPは公式Python SDKのStreamable HTTPを使い、APIとは別のCloud Runサービスで動かす。公開ツールは参照系から始める

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Ruffのバージョンは `src/api/uv.lock` を唯一の情報源とします。
 
 React + Vite ベースのSPAです。Cloudflare Workers（Static Assets）でデプロイされています。
 
-`worker/index.ts` が `/api/*` を受けて Cloud Run へプロキシします。これによりフロントとAPIが同一オリジンになるため、フロント側はAPIを**常に相対パスで叩きます**（`API_BASE_URL` のような基底URLは持ちません）。バックエンドのオリジンは Worker の Secret（`API_ORIGIN`）にあり、リポジトリにもクライアントバンドルにも入れません。
+`worker/index.ts` が `/api/*` と `/mcp` を、それぞれAPI/MCP用Cloud Runへプロキシします。フロント側はAPIを**常に相対パスで叩きます**（`API_BASE_URL` のような基底URLは持ちません）。オリジンは Worker の Secret（`API_ORIGIN` / `MCP_ORIGIN`）にあり、リポジトリにもクライアントバンドルにも入れません。
 
 - Workersランタイムの型 `worker-configuration.d.ts` は生成物なのでコミットしない（gitignore済み）。14000行超あるうえ、`wrangler types` がローカルの `.dev.vars` の変数名を取り込むためマシン間で内容が一致しない。`pnpm typecheck` が毎回先頭で生成するので、手動実行は不要（単体で回したいときは `pnpm cf-typegen`）
 - `compatibility_date` は同梱 workerd がサポートする上限日以下にする。超えると `wrangler dev` が起動しない。制約は一方向（wrangler を上げると上限が上がるだけ）なので、**依存更新に追随して上げる必要はない**。日付でゲートされた挙動が欲しいときだけ意図して上げる
@@ -176,6 +176,9 @@ FastAPIベースのREST APIです。PostgreSQLをデータベースとして使�
 # 開発サーバ起動
 uv run uvicorn stock.app:app --reload --port 8000
 
+# MCPサーバ起動（Streamable HTTP: http://localhost:8001/mcp）
+uv run uvicorn stock.mcp.app:app --reload --port 8001
+
 # 依存関係のインストール（Socket Firewall経由）
 sfw uv sync
 
@@ -202,13 +205,15 @@ uv run alembic downgrade -1
 
 本人確認とログインセッションは **Cloudflare Access** に委譲する。アプリはパスワードも独自トークンも持たない。判断の経緯は `docs/adr/0004-cloudflare-access-authentication.md`。
 
-処理の流れは3層に分かれる。
+処理の流れはフレームワーク非依存の中核と、REST/MCP固有の入口に分かれる。
 
 | ファイル | 責務 |
 |---------|------|
 | `stock/cloudflare_access.py` | `Cf-Access-Jwt-Assertion` の検証（JWKS取得・署名・issuer・audience・有効期限）。DBにもFastAPIにも依存しない |
 | `stock/services/user_service.py` | 検証済みの外部ID (`issuer`, `sub`) からアプリ内 `users` を解決する。未紐付けのユーザーはAccessが確認済みのメールアドレスで初回だけ紐付ける |
-| `stock/auth.py` | FastAPIの依存性。上2つを繋ぎ、RLS用の `app.current_user_id` を設定する |
+| `stock/user_context.py` | User解決とRLS設定を同じDBセッションへ束縛する。REST/MCP共通 |
+| `stock/auth.py` | FastAPIの依存性として共通コンテキストを接続する |
+| `stock/mcp/` | MCP全体へ認証を強制し、RLS済みコンテキストからService層を呼ぶ |
 
 - 認証は `FastAPI(dependencies=[Depends(get_access_identity)])` でアプリ全体に掛ける。ルート単位で書き忘れても素通りしない
 - Cloud Run の `*.run.app` は公開されたままなので、この検証がCloudflareを迂回した直アクセスの防波堤になる
@@ -216,6 +221,7 @@ uv run alembic downgrade -1
 - Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
 - `is_admin`、データ所有権、PostgreSQL RLS はアプリ側の責務。Accessのメールアドレスやグループを検証なしに権限へ変換しない
 - 定期ジョブはGoogle Cloud Run JobsでDB直結のため、HTTP経由のAPI認証経路は持たない
+- MCPは公式Python SDKのStreamable HTTPを使い、APIとは別のCloud Runサービスで動かす。公開ツールは参照系から始める
 
 ローカル開発とテストでの差し替えは以下。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ uv run alembic downgrade -1
 | ファイル | 責務 |
 |---------|------|
 | `stock/cloudflare_access.py` | `Cf-Access-Jwt-Assertion` の検証（JWKS取得・署名・issuer・audience・有効期限）。DBにもFastAPIにも依存しない |
-| `stock/services/user_service.py` | 検証済みの外部ID (`issuer`, `sub`) からアプリ内 `users` を解決する。未紐付けのユーザーはAccessが確認済みのメールアドレスで初回だけ紐付ける |
+| `stock/services/user_service.py` | Accessが確認済みのメールアドレスからアプリ内 `users` を解決する。JWTの `sub` はAccess applicationごとに変わりうるため紐付けキーにしない |
 | `stock/user_context.py` | User解決とRLS設定を同じDBセッションへ束縛する。REST/MCP共通 |
 | `stock/auth.py` | FastAPIの依存性として共通コンテキストを接続する |
 | `stock/mcp/` | MCP全体へ認証を強制し、RLS済みコンテキストからService層を呼ぶ |
@@ -218,7 +218,7 @@ uv run alembic downgrade -1
 - 認証は `FastAPI(dependencies=[Depends(get_access_identity)])` でアプリ全体に掛ける。ルート単位で書き忘れても素通りしない
 - Cloud Run の `*.run.app` は公開されたままなので、この検証がCloudflareを迂回した直アクセスの防波堤になる
 - 未認証は401、Access認証済みだがアプリ未登録は403
-- Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
+- Swagger UI (`/docs`) が使えるのはローカルのみ。サイト側はWorkerが `/api/*` と `/mcp` しか通さず、`*.run.app` 側はAccessのヘッダーが付かない
 - `is_admin`、データ所有権、PostgreSQL RLS はアプリ側の責務。Accessのメールアドレスやグループを検証なしに権限へ変換しない
 - 定期ジョブはGoogle Cloud Run JobsでDB直結のため、HTTP経由のAPI認証経路は持たない
 - MCPは公式Python SDKのStreamable HTTPを使い、APIとは別のCloud Runサービスで動かす。公開ツールは参照系から始める

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ InvestLogixは、日本株・米国株の取引/保有/配当を記録し、ポ�
 - ポートフォリオ分析（資産推移、通貨/市場別の分布、銘柄別配当割合、サマリー）
 - LINE通知（ポートフォリオ状況の通知）
 - 認証（Cloudflare Access）
+- OAuth対応MCP（ポートフォリオ・保有銘柄・月次配当の参照）
 
 ## 構成
 
@@ -26,8 +27,8 @@ InvestLogixは、日本株・米国株の取引/保有/配当を記録し、ポ�
 
 ### インフラ
 - フロントエンド: Cloudflare Workers（Static Assets）
-  - `/api/*` は Worker が Cloud Run へプロキシする。フロントとAPIを同一オリジンにすることで、APIリクエストもCloudflare Accessの保護下を通る
-  - バックエンドのオリジンは Worker の Secret（`API_ORIGIN`）に置くため、リポジトリにもクライアントバンドルにも現れない
+  - `/api/*` と `/mcp` は Worker が別々の Cloud Run サービスへプロキシする
+  - オリジンは Worker の Secret（`API_ORIGIN` / `MCP_ORIGIN`）に置くため、リポジトリにもクライアントバンドルにも現れない
 - 認証: Cloudflare Access（Zero Trust）
   - 本人確認とログインセッションはAccessが持つ。アプリはパスワードも独自トークンも保持しない
   - APIは全リクエストで `Cf-Access-Jwt-Assertion` の署名・issuer・audience・有効期限を検証し、Cloudflareを迂回した直アクセスを拒否する
@@ -35,6 +36,7 @@ InvestLogixは、日本株・米国株の取引/保有/配当を記録し、ポ�
   - 設定手順は [`infra/README.md`](infra/README.md) を参照
 - バックエンド: Google Cloud Run
   - API は Cloud Run Service
+  - MCP は別の Cloud Run Service（公式Python SDK / Streamable HTTP）
   - 定時ジョブは Cloud Run Jobs ＋ Cloud Scheduler
 - DB: Supabase（マネージド PostgreSQL）
 - シークレットは事前に Secret Manager に登録
@@ -76,6 +78,16 @@ docker compose up -d --build
 - API: `http://localhost:8000`
 - APIドキュメント（Swagger）: `http://localhost:8000/docs`
 
+MCPも起動する場合:
+
+```bash
+cd src/api
+uv run uvicorn stock.mcp.app:app --reload --port 8001
+```
+
+- MCP: `http://localhost:8001/mcp`
+- `DEV_AUTH_EMAIL` のユーザーへ解決し、RESTと同じRLSを適用する
+
 停止する場合:
 
 ```bash
@@ -115,7 +127,7 @@ pnpm dev
 
 ```bash
 cd src/web
-printf 'API_ORIGIN=http://localhost:8000\n' > .dev.vars
+printf 'API_ORIGIN=http://localhost:8000\nMCP_ORIGIN=http://localhost:8001\n' > .dev.vars
 pnpm build && pnpm cf-dev
 ```
 
@@ -158,7 +170,7 @@ pnpm check
 - Backend: `src/api/.env.sample` を参考に `src/api/.env` を作成
   - 認証: 本番は `CF_ACCESS_TEAM_DOMAIN` と `CF_ACCESS_AUD`（Cloudflare Zero Trust から取得）。ローカルは代わりに `DEV_AUTH_EMAIL` を使う
 - Frontend: 通常は設定不要。Vite の dev proxy の転送先を変える場合のみ `API_PROXY_TARGET` を指定する
-- Cloudflare Worker: バックエンドのオリジンは `API_ORIGIN`。本番は `wrangler secret put API_ORIGIN`、手元は `src/web/.dev.vars` に置く（どちらもリポジトリには入れない）
+- Cloudflare Worker: オリジンは `API_ORIGIN` / `MCP_ORIGIN`。本番は `wrangler secret put`、手元は `src/web/.dev.vars` に置く（どちらもリポジトリには入れない）
 
 ## API仕様
 

--- a/docs/adr/0004-cloudflare-access-authentication.md
+++ b/docs/adr/0004-cloudflare-access-authentication.md
@@ -26,7 +26,7 @@ OAuth だけを別に用意すると、同じ利用者に対して認証主体�
 **Web と MCP の認証を Cloudflare Access に委譲する。アプリケーション内の認可は InvestLogix に残す。**
 
 - Cloudflare Access は本人確認、ログインセッション、MCP の OAuth フローを担当する
-- InvestLogix は Access が発行した署名済み JWT を検証し、`iss` と `sub` から内部の `user_id` を解決する
+- InvestLogix は Access が発行した署名済み JWT を検証し、確認済みのメールアドレスから内部の `user_id` を解決する
 - `is_admin`、データ所有権、PostgreSQL RLS は引き続き InvestLogix が判定する
 - Access のメールアドレスやグループを、検証なしにアプリケーション権限へ直接変換しない
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -23,6 +23,11 @@ TF_VAR_image_uri="asia-northeast1-docker.pkg.dev/your-gcp-project-id/cloud-run-s
 TF_VAR_db_user="<DB_USER の値>"
 TF_VAR_db_host="<DB_HOST の値>"
 
+# Cloudflare Access。WebとMCPは別applicationなのでAUDも分ける。
+TF_VAR_cf_access_team_domain="<team>.cloudflareaccess.com"
+TF_VAR_cf_access_aud="<Web application audience tag>"
+TF_VAR_cf_access_mcp_aud="<MCP application audience tag>"
+
 # CD (GitHub Actions) 用。WIF の attribute_condition で repository を絞るため必須。
 TF_VAR_github_repository="<github-owner>/<repo>"
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -38,7 +38,7 @@ InvestLogix の本番 Google Cloud リソース（API/MCP Cloud Run Service / Jo
 ### 公開リポジトリ向けの秘匿
 - プロジェクト ID・Supabase ホスト等の識別子は `variable` 化し、`infra/.env` に書いた `TF_VAR_*` を `set -a; source .env; set +a` で読み込んで注入する（`TF_VAR_*` は OpenTofu でもそのまま読まれる）。
 - Secret 値は Secret Manager に置き、`data "google_secret_manager_secret"` で参照のみ。state には機密値が乗らない（state 自体も非公開 GCS バケットに置く）。
-- state バックエンドのバケット名は `backend.hcl`（gitignore 対象）に書き、`tofu init -backend-config=backend.hcl` で渡す。`.tf` には書かない。
+- state バックエンドのバケット名は `backend.hcl`（gitignore 対象）に書き、`tofu init -backend-config backend.hcl` で渡す。`.tf` には書かない。PowerShell は `-flag=value` を2つの引数に割ってしまうため、`=` ではなくスペースで区切る。
 
 ### GitHub Actions CD との役割分担
 - コンテナイメージタグ (`<image>:<commit-sha>`) は GitHub Actions の `api-cd.yml` が docker push → API/MCPの `gcloud run deploy` / `gcloud run jobs update` で直接反映する。

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,6 +1,6 @@
 # infra/ — Google Cloud インフラ (OpenTofu)
 
-InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Scheduler / Service Accounts / Secret Manager IAM）を OpenTofu で管理する。
+InvestLogix の本番 Google Cloud リソース（API/MCP Cloud Run Service / Jobs / Scheduler / Service Accounts / Secret Manager IAM）を OpenTofu で管理する。
 
 > CLI は `tofu`。HCL は Terraform 互換なので、`hashicorp/google` プロバイダ等はそのまま使える。
 
@@ -25,8 +25,9 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
 | `service_accounts.tf` | ランタイム / invoker / CD deployer の Service Account と IAM |
 | `secrets.tf` | 既存シークレットの data 参照と IAM 付与 |
 | `cloud_run_service.tf` | API 用 Cloud Run Service |
-| `cloud_run_jobs.tf` | バッチジョブ × 3 と invoker IAM |
-| `cloud_scheduler.tf` | Cloud Scheduler × 3（OAuth 認証で Job をキック） |
+| `cloud_run_mcp.tf` | MCP 用 Cloud Run Service（APIと同じイメージ、別プロセス） |
+| `cloud_run_jobs.tf` | バッチジョブ × 2 と invoker IAM |
+| `cloud_scheduler.tf` | Cloud Scheduler × 2（OAuth 認証で Job をキック） |
 | `artifact_registry.tf` | コンテナイメージ置き場 |
 | `workload_identity.tf` | GitHub Actions が鍵レスで成り代わるための WIF |
 | `monitoring.tf` | Cloud Run Jobs の失敗を検知する Notification Channel と Alert Policy |
@@ -40,7 +41,7 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
 - state バックエンドのバケット名は `backend.hcl`（gitignore 対象）に書き、`tofu init -backend-config=backend.hcl` で渡す。`.tf` には書かない。
 
 ### GitHub Actions CD との役割分担
-- コンテナイメージタグ (`<image>:<commit-sha>`) は GitHub Actions の `api-cd.yml` が docker push → `gcloud run deploy` / `gcloud run jobs update` で直接反映する。
+- コンテナイメージタグ (`<image>:<commit-sha>`) は GitHub Actions の `api-cd.yml` が docker push → API/MCPの `gcloud run deploy` / `gcloud run jobs update` で直接反映する。
 - OpenTofu は image を `ignore_changes` で無視する。**OpenTofu は構造（env, SA, scaling, schedule, WIF, AR）を管理、GitHub Actions は image を管理。**
 - 同じ理由で Cloud Run の `client` / `client_version` / `revision` 等の自動更新フィールドも無視する。
 
@@ -56,12 +57,24 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
   | `TF_VAR_cf_access_aud` | Zero Trust → Access → Applications → 対象アプリの **Application Audience (AUD) Tag** |
 
 - Access application を作り直すと AUD タグが変わる。変えたら `.env` を更新して `tofu apply` する。
-- 第 2 段階で MCP 用の Access application を追加するときは、application を分けて別の AUD を使う（同じ IdP とユーザー解決規則は共有する）。
+- MCP は専用ホストの `/mcp` を Worker から別Cloud Runへ転送する。Access applicationもWeb用と分け、Managed OAuthを有効にする。
+- Managed OAuthのアクセストークンはCloudflare側で利用者へ解決され、オリジンにはWebと同じ `Cf-Access-Jwt-Assertion` が届く。MCP側も署名・issuer・専用AUDを検証する。
+
+### MCPの初期構築
+
+1. MCP用ホスト名（例: `mcp.example.com`）を決め、同じWorkerのCustom Domainとして追加する。
+2. Zero Trust → Access controls → AI controls → MCP servers で `https://<MCPホスト>/mcp` を登録し、Webと同じIdP/許可ポリシーを設定する。
+3. 作成したMCP applicationのAdvanced settingsでManaged OAuthを有効化する。ローカルクライアントを使う場合はlocalhost/loopback redirectも許可する。
+4. MCP applicationのAUDを `TF_VAR_cf_access_mcp_aud` に設定し、`tofu apply` で専用Cloud RunとSAを作る。
+5. `tofu output -raw mcp_service_uri` の値を `cd src/web && pnpm wrangler secret put MCP_ORIGIN` でWorker Secretへ登録する。
+6. MCP InspectorまたはOAuth対応MCPクライアントから `https://<MCPホスト>/mcp` へ接続し、ブラウザ認証後に3つの参照ツールが見えることを確認する。
+
+MCPのAccess token lifetimeは5〜15分、grant sessionは1〜2週間を目安にする。OAuthはAccessが提供するため、MCPサーバー自身にOAuthエンドポイントやクライアントシークレットは置かない。
 
 ### CD 用リソースと GitHub Actions Variables の同期
 - WIF / Artifact Registry / Deployer SA は OpenTofu 管理下にある。
 - ワークフロー側は GCP プロジェクト ID 等の識別子を YAML に書かない（public リポのため）。`tofu output` の値を GitHub の **Settings → Secrets and variables → Actions → Variables** に手動で登録する。
-- 必要な Variables: `WIF_PROVIDER`, `DEPLOYER_SA`, `IMAGE_BASE`, `GCP_REGION`, `SERVICE_NAME`。
+- 必要な Variables: `WIF_PROVIDER`, `DEPLOYER_SA`, `IMAGE_BASE`, `GCP_REGION`, `SERVICE_NAME`, `MCP_SERVICE_NAME`。
 - 取得手順:
   ```bash
   cd infra
@@ -70,7 +83,7 @@ InvestLogix の本番 Google Cloud リソース（Cloud Run Service / Jobs / Sch
   tofu output -raw deployer_sa_email
   tofu output -raw image_base
   ```
-  これらの値と、`var.region` (`asia-northeast1`) / `var.service_name` (`investlogix-api`) を Variables に登録する。WIF / AR / SA の構成を変えたときだけ再同期すればよい。
+  これらの値と、`var.region` (`asia-northeast1`) / `var.service_name` (`investlogix-api`) / `var.mcp_service_name` (`investlogix-mcp`) を Variables に登録する。WIF / AR / SA の構成を変えたときだけ再同期すればよい。
 
 ---
 
@@ -121,7 +134,7 @@ unset VALUE
 
 ## イメージのデプロイ
 
-main への push で `.github/workflows/api-cd.yml` が起動し、build → push → `gcloud run deploy` (Service) → `gcloud run jobs update` (Jobs) を 1 本のワークフローで実行する。OpenTofu は image を `ignore_changes` しているので何もしない。
+main への push で `.github/workflows/api-cd.yml` が起動し、build → push → `gcloud run deploy` (API/MCP) → `gcloud run jobs update` (Jobs) を 1 本のワークフローで実行する。OpenTofu は image を `ignore_changes` しているので何もしない。
 
 ## Artifact Registry の初回 import
 

--- a/infra/cloud_run_mcp.tf
+++ b/infra/cloud_run_mcp.tf
@@ -1,0 +1,109 @@
+resource "google_cloud_run_v2_service" "mcp" {
+  name                = var.mcp_service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+
+  # Workerから*.run.appへ転送する。直アクセスはMCP側のAccess JWT検証で拒否する。
+  default_uri_disabled = false
+  invoker_iam_disabled = true
+
+  template {
+    service_account                  = google_service_account.mcp_runtime.email
+    timeout                          = "300s"
+    max_instance_request_concurrency = 80
+
+    scaling {
+      max_instance_count = 5
+    }
+
+    containers {
+      image = var.image_uri
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+        cpu_idle          = true
+        startup_cpu_boost = true
+      }
+
+      env {
+        name  = "APP_MODULE"
+        value = "stock.mcp.app:app"
+      }
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "DB_USER"
+        value = var.db_user
+      }
+      env {
+        name  = "DB_HOST"
+        value = var.db_host
+      }
+      env {
+        name  = "DB_PORT"
+        value = var.db_port
+      }
+      env {
+        name  = "DB_NAME"
+        value = var.db_name
+      }
+      env {
+        name  = "CF_ACCESS_TEAM_DOMAIN"
+        value = var.cf_access_team_domain
+      }
+      env {
+        name  = "CF_ACCESS_AUD"
+        value = var.cf_access_mcp_aud
+      }
+
+      dynamic "env" {
+        for_each = local.mcp_secrets
+        content {
+          name = env.value
+          value_source {
+            secret_key_ref {
+              secret  = data.google_secret_manager_secret.all[env.value].secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      startup_probe {
+        failure_threshold = 1
+        period_seconds    = 240
+        timeout_seconds   = 240
+        tcp_socket {
+          port = 8080
+        }
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  depends_on = [google_secret_manager_secret_iam_member.mcp_runtime]
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+      template[0].labels,
+      template[0].revision,
+      labels,
+      client,
+      client_version,
+    ]
+  }
+}

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -24,6 +24,11 @@ locals {
     "OPENAI_API_KEY",
   ]
 
+  # MCPは参照系ツールだけを提供するため、外部APIのシークレットは渡さない。
+  mcp_secrets = [
+    "DB_PASSWORD",
+  ]
+
   jobs_secrets = [
     "DB_PASSWORD",
     "LINE_CHANNEL_ACCESS_TOKEN",
@@ -33,7 +38,7 @@ locals {
     "OPENAI_API_KEY",
   ]
 
-  all_secrets = toset(concat(local.service_secrets, local.jobs_secrets))
+  all_secrets = toset(concat(local.service_secrets, local.mcp_secrets, local.jobs_secrets))
 
   # CD 用リソースの ID。環境ごとに変える必要がないため variable ではなく local。
   artifact_registry_image_name = "investlogix/investlogix-api"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -7,6 +7,15 @@ output "service_runtime_sa_email" {
   value = google_service_account.api_runtime.email
 }
 
+output "mcp_service_uri" {
+  value     = google_cloud_run_v2_service.mcp.uri
+  sensitive = true
+}
+
+output "mcp_runtime_sa_email" {
+  value = google_service_account.mcp_runtime.email
+}
+
 output "jobs_runtime_sa_email" {
   value = google_service_account.jobs_runtime.email
 }

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -16,6 +16,16 @@ resource "google_secret_manager_secret_iam_member" "api_runtime" {
   member    = "serviceAccount:${google_service_account.api_runtime.email}"
 }
 
+# MCPランタイムには参照ツールに必要なDB接続シークレットだけを許可する。
+resource "google_secret_manager_secret_iam_member" "mcp_runtime" {
+  for_each = toset(local.mcp_secrets)
+
+  project   = data.google_secret_manager_secret.all[each.value].project
+  secret_id = data.google_secret_manager_secret.all[each.value].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.mcp_runtime.email}"
+}
+
 # Cloud Run Jobs ランタイム SA に対し、Jobs が参照する全シークレットの読取権限を付与
 resource "google_secret_manager_secret_iam_member" "jobs_runtime" {
   for_each = toset(local.jobs_secrets)

--- a/infra/service_accounts.tf
+++ b/infra/service_accounts.tf
@@ -3,6 +3,11 @@ resource "google_service_account" "api_runtime" {
   display_name = "Cloud Run Service runtime"
 }
 
+resource "google_service_account" "mcp_runtime" {
+  account_id   = var.mcp_runtime_sa_id
+  display_name = "Cloud Run MCP runtime"
+}
+
 resource "google_service_account" "jobs_runtime" {
   account_id   = var.jobs_runtime_sa_id
   display_name = "Cloud Run Jobs runtime"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -28,6 +28,11 @@ variable "cf_access_aud" {
   description = "Web 用 Cloudflare Access application の Audience タグ。他アプリ向けに発行された Access JWT の使い回しを防ぐ。"
 }
 
+variable "cf_access_mcp_aud" {
+  type        = string
+  description = "MCP用Cloudflare Access applicationのAudienceタグ。Web用とは別の値を設定する。"
+}
+
 variable "region" {
   type        = string
   default     = "asia-northeast1"
@@ -49,9 +54,19 @@ variable "service_name" {
   default = "investlogix-api"
 }
 
+variable "mcp_service_name" {
+  type    = string
+  default = "investlogix-mcp"
+}
+
 variable "service_runtime_sa_id" {
   type    = string
   default = "investlogix-api-runtime"
+}
+
+variable "mcp_runtime_sa_id" {
+  type    = string
+  default = "investlogix-mcp-runtime"
 }
 
 variable "jobs_runtime_sa_id" {

--- a/src/api/.env.sample
+++ b/src/api/.env.sample
@@ -8,8 +8,10 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=investlogix
 
-# Authentication settings
-JWT_SECRET_KEY=your-secret-key  # 本番環境では強力な秘密鍵に変更してください
+# Authentication settings (production: Cloudflare Access / local: DEV_AUTH_EMAIL)
+CF_ACCESS_TEAM_DOMAIN=
+CF_ACCESS_AUD=
+DEV_AUTH_EMAIL=test@example.com
 
 # J-Quants API settings
 JQUANTS_API_KEY=your-api-key  # J-Quantsダッシュボードで発行したAPIキー

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -26,5 +26,6 @@ RUN sfw uv sync --frozen --no-dev
 
 EXPOSE 8080
 
-# Cloud RunはPORT環境変数を注入する
-CMD ["sh", "-c", "uv run uvicorn stock.app:app --host 0.0.0.0 --port ${PORT:-8080} --log-level info"]
+# 同じイメージをAPI/MCPで使い、Cloud Run側のAPP_MODULEだけで起動対象を分ける。
+# Cloud RunはPORT環境変数を注入する。
+CMD ["sh", "-c", "uv run uvicorn ${APP_MODULE:-stock.app:app} --host 0.0.0.0 --port ${PORT:-8080} --log-level info"]

--- a/src/api/alembic/versions/d5e6f7a8b9c0_drop_access_identity_columns.py
+++ b/src/api/alembic/versions/d5e6f7a8b9c0_drop_access_identity_columns.py
@@ -1,0 +1,36 @@
+"""drop cloudflare access identity columns from users
+
+Revision ID: d5e6f7a8b9c0
+Revises: c3f1a2b4d5e6
+Create Date: 2026-08-08 10:00:00.000000
+
+Cloudflare Access との紐付けキーを (issuer, sub) から email へ移す。
+JWTの `sub` は Access application ごとに変わりうるため、WebとMCPで別々の
+application を使う構成では共通の紐付けキーにできない。email は Access が
+確認済みのクレームで、users.email には既に一意制約があるためそのまま使える。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | None = "c3f1a2b4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_users_access_identity", "users", type_="unique")
+    op.drop_column("users", "access_subject")
+    op.drop_column("users", "access_issuer")
+
+
+def downgrade() -> None:
+    # 紐付け値は復元できない。列を戻したうえで、次のログインで再度紐付けさせる
+    op.add_column("users", sa.Column("access_issuer", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("access_subject", sa.String(length=255), nullable=True))
+    op.create_unique_constraint("uq_users_access_identity", "users", ["access_issuer", "access_subject"])

--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "loguru>=0.7.3",
     "setuptools>=83.0.0",
     "openai>=2.48.0",
+    "mcp>=2.0.0",
 ]
 
 [tool.uv]

--- a/src/api/stock/auth.py
+++ b/src/api/stock/auth.py
@@ -6,19 +6,19 @@ FastAPI の認証依存性
 パスワードやトークンの発行は一切持たない。
 """
 
-from collections.abc import AsyncGenerator
-
 from fastapi import Depends, HTTPException, Request, status
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .cloudflare_access import ACCESS_JWT_HEADER, AccessIdentity, AccessTokenError, verify_access_token
-from .database import get_db, set_rls_user_id, settings
+from .cloudflare_access import (
+    ACCESS_JWT_HEADER,
+    AccessIdentity,
+    AccessTokenError,
+    authenticate_access_request,
+)
+from .database import get_db
 from .models import User
-from .services.user_service import UserService
-
-# ローカル開発用の擬似Accessの issuer。実在しないドメインにして本番のIDと衝突させない
-DEV_ACCESS_ISSUER = "https://dev.invalid"
+from .user_context import UserContext, UserNotRegisteredError, create_user_context
 
 
 def _unauthenticated() -> HTTPException:
@@ -37,42 +37,35 @@ async def get_access_identity(request: Request) -> AccessIdentity:
     素通りしないようにするためで、ルート側の get_current_user とは結果を共有する。
     Cloudflare を迂回した直アクセスはヘッダーが無いか署名が不正なので、ここで落ちる。
     """
-    if settings.DEV_AUTH_EMAIL:
-        # ローカル開発ではCloudflareを経由しないため、擬似的な外部IDを組み立てる。
-        # 本番でこの値が設定されていた場合は Settings の検証で起動時に失敗する
-        return AccessIdentity(
-            issuer=DEV_ACCESS_ISSUER,
-            subject=settings.DEV_AUTH_EMAIL,
-            email=settings.DEV_AUTH_EMAIL,
-        )
-
     token = request.headers.get(ACCESS_JWT_HEADER)
-    if not token:
-        raise _unauthenticated()
-
     try:
-        return await verify_access_token(token)
+        return await authenticate_access_request(token)
     except AccessTokenError as e:
         logger.warning("Access JWTの検証に失敗しました action=verify reason={}", str(e))
         raise _unauthenticated() from e
 
 
-async def get_current_user(
+async def get_user_context(
     identity: AccessIdentity = Depends(get_access_identity),
     db: AsyncSession = Depends(get_db),
-) -> User:
+) -> UserContext:
     """
     認証済みの外部IDからアプリ内ユーザーを取得する
     - アプリに登録されていない利用者の場合: 403 Forbidden
     """
-    user = await UserService(db).resolve_by_access_identity(identity)
-    if user is None:
+    try:
+        return await create_user_context(db, identity)
+    except UserNotRegisteredError as e:
         logger.warning("Access IDに対応するUserがいません action=select email={}", identity.email)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="このアカウントはInvestLogixに登録されていません",
-        )
-    return user
+        ) from e
+
+
+async def get_current_user(context: UserContext = Depends(get_user_context)) -> User:
+    """認証・ユーザー解決済みコンテキストから利用者を返す。"""
+    return context.user
 
 
 async def get_admin_user(current_user: User = Depends(get_current_user)) -> User:
@@ -88,14 +81,10 @@ async def get_admin_user(current_user: User = Depends(get_current_user)) -> User
     return current_user
 
 
-async def get_db_for_user(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-) -> AsyncGenerator[AsyncSession]:
+async def get_db_for_user(context: UserContext = Depends(get_user_context)) -> AsyncSession:
     """
     RLS用のuser_idを設定したデータベースセッションを返す依存性注入
     - 認証済みユーザーのuser_idをPostgreSQLセッション変数に設定する
     - 使用例: db: AsyncSession = Depends(get_db_for_user)
     """
-    await set_rls_user_id(db, current_user.user_id)
-    yield db
+    return context.db

--- a/src/api/stock/cloudflare_access.py
+++ b/src/api/stock/cloudflare_access.py
@@ -22,6 +22,9 @@ from .utils.cache import timed_cache
 # Cloudflare が Access 通過後のリクエストに付与する JWT のヘッダー名
 ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion"
 
+# ローカル開発用の擬似Access issuer。実在しないドメインにして本番のIDと衝突させない。
+DEV_ACCESS_ISSUER = "https://dev.invalid"
+
 # Cloudflare の署名鍵は数週間単位でしか入れ替わらないため、1時間キャッシュすれば足りる
 JWKS_CACHE_SECONDS = 3600
 JWKS_TIMEOUT_SECONDS = 5.0
@@ -85,3 +88,16 @@ async def verify_access_token(token: str) -> AccessIdentity:
         raise AccessTokenError("Access JWTに sub / email が含まれていません")
 
     return AccessIdentity(issuer=issuer, subject=subject, email=email)
+
+
+async def authenticate_access_request(token: str | None) -> AccessIdentity:
+    """HTTPリクエストをAccess外部IDへ変換する。REST/MCPで同じ入口を使う。"""
+    if settings.DEV_AUTH_EMAIL:
+        return AccessIdentity(
+            issuer=DEV_ACCESS_ISSUER,
+            subject=settings.DEV_AUTH_EMAIL,
+            email=settings.DEV_AUTH_EMAIL,
+        )
+    if not token:
+        raise AccessTokenError("Access JWTがありません")
+    return await verify_access_token(token)

--- a/src/api/stock/cloudflare_access.py
+++ b/src/api/stock/cloudflare_access.py
@@ -22,9 +22,6 @@ from .utils.cache import timed_cache
 # Cloudflare が Access 通過後のリクエストに付与する JWT のヘッダー名
 ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion"
 
-# ローカル開発用の擬似Access issuer。実在しないドメインにして本番のIDと衝突させない。
-DEV_ACCESS_ISSUER = "https://dev.invalid"
-
 # Cloudflare の署名鍵は数週間単位でしか入れ替わらないため、1時間キャッシュすれば足りる
 JWKS_CACHE_SECONDS = 3600
 JWKS_TIMEOUT_SECONDS = 5.0
@@ -37,15 +34,11 @@ class AccessTokenError(Exception):
 @dataclass(frozen=True)
 class AccessIdentity:
     """
-    Access が保証する外部ID
+    Access が保証する利用者ID
 
-    - issuer: Access チームのURL（例: https://example.cloudflareaccess.com）
-    - subject: Access が採番する利用者ID。IdP側でメールが変わっても不変
-    - email: IdP が確認済みのメールアドレス
+    - email: IdP が確認済みのメールアドレス。これがアプリ内ユーザーとの紐付けキー
     """
 
-    issuer: str
-    subject: str
     email: str
 
 
@@ -81,23 +74,18 @@ async def verify_access_token(token: str) -> AccessIdentity:
     except (JWTError, httpx.HTTPError) as e:
         raise AccessTokenError(str(e)) from e
 
-    subject = claims.get("sub")
     email = claims.get("email")
-    if not subject or not email:
-        # サービストークンでの認証は sub / email を持たない。第1段階では利用者ログインのみ扱う
-        raise AccessTokenError("Access JWTに sub / email が含まれていません")
+    if not email:
+        # サービストークンでの認証は email を持たない。第1段階では利用者ログインのみ扱う
+        raise AccessTokenError("Access JWTにemailが含まれていません")
 
-    return AccessIdentity(issuer=issuer, subject=subject, email=email)
+    return AccessIdentity(email=email)
 
 
 async def authenticate_access_request(token: str | None) -> AccessIdentity:
-    """HTTPリクエストをAccess外部IDへ変換する。REST/MCPで同じ入口を使う。"""
+    """HTTPリクエストをAccess利用者IDへ変換する。REST/MCPで同じ入口を使う。"""
     if settings.DEV_AUTH_EMAIL:
-        return AccessIdentity(
-            issuer=DEV_ACCESS_ISSUER,
-            subject=settings.DEV_AUTH_EMAIL,
-            email=settings.DEV_AUTH_EMAIL,
-        )
+        return AccessIdentity(email=settings.DEV_AUTH_EMAIL)
     if not token:
         raise AccessTokenError("Access JWTがありません")
     return await verify_access_token(token)

--- a/src/api/stock/database.py
+++ b/src/api/stock/database.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from enum import Enum
 
 from pydantic import field_validator, model_validator
@@ -148,12 +150,9 @@ AsyncSessionLocal = async_sessionmaker(
 )
 
 
-async def get_db():
-    """
-    データベースセッションの依存性注入
-    - 戻り値: 非同期セッション
-    - 使用例: db: AsyncSession = Depends(get_db)
-    """
+@asynccontextmanager
+async def session_scope() -> AsyncIterator[AsyncSession]:
+    """トランザクション境界を持つDBセッションを提供する。"""
     async with AsyncSessionLocal() as session:
         try:
             yield session
@@ -161,8 +160,16 @@ async def get_db():
         except Exception:
             await session.rollback()
             raise
-        finally:
-            await session.close()
+
+
+async def get_db() -> AsyncGenerator[AsyncSession]:
+    """
+    データベースセッションの依存性注入
+    - 戻り値: 非同期セッション
+    - 使用例: db: AsyncSession = Depends(get_db)
+    """
+    async with session_scope() as session:
+        yield session
 
 
 async def set_rls_user_id(session: AsyncSession, user_id: int) -> None:

--- a/src/api/stock/mcp/__init__.py
+++ b/src/api/stock/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""InvestLogix MCP server package."""

--- a/src/api/stock/mcp/app.py
+++ b/src/api/stock/mcp/app.py
@@ -1,0 +1,27 @@
+"""Streamable HTTPで提供するInvestLogix MCPアプリケーション。"""
+
+from mcp.server import MCPServer
+
+from ..database import settings
+from .middleware import AccessUserContextMiddleware
+from .tools import register_tools
+
+mcp = MCPServer(
+    name="investlogix",
+    title="InvestLogix",
+    description="認証した利用者自身の投資ポートフォリオを参照するMCPサーバー",
+    instructions="参照系ツールだけを提供します。金額は特記がなければ日本円です。",
+    version="1.0.0",
+)
+register_tools(mcp)
+
+mcp_http_app = mcp.streamable_http_app(
+    streamable_http_path="/mcp",
+    stateless_http=True,
+    json_response=True,
+    host=settings.HOST,
+)
+
+# 認証をSDKの各ツールではなくASGI境界で強制する。initialize/tools/listを含め、
+# Cloud Runへ直接届いた未認証リクエストがMCP層へ入ることはない。
+app = AccessUserContextMiddleware(mcp_http_app)

--- a/src/api/stock/mcp/middleware.py
+++ b/src/api/stock/mcp/middleware.py
@@ -1,0 +1,92 @@
+"""Cloudflare Access認証をMCPのASGIアプリ全体へ強制するミドルウェア。"""
+
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from typing import cast
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from mcp.server.mcpserver import Context
+
+from ..cloudflare_access import (
+    ACCESS_JWT_HEADER,
+    AccessIdentity,
+    AccessTokenError,
+    authenticate_access_request,
+)
+from ..database import session_scope
+from ..user_context import UserContext, UserNotRegisteredError, create_user_context
+
+USER_CONTEXT_SCOPE_KEY = "investlogix.user_context"
+IdentityProvider = Callable[[str | None], Awaitable[AccessIdentity]]
+SessionScopeFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+
+
+class AccessUserContextMiddleware:
+    """Access JWT検証・User解決・RLS設定を済ませてからMCPへ渡す。"""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        identity_provider: IdentityProvider = authenticate_access_request,
+        session_scope_factory: SessionScopeFactory = session_scope,
+    ):
+        self.app = app
+        self.identity_provider = identity_provider
+        self.session_scope_factory = session_scope_factory
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        token = Headers(scope=scope).get(ACCESS_JWT_HEADER)
+        try:
+            identity = await self.identity_provider(token)
+        except AccessTokenError as error:
+            logger.warning("MCP Access JWTの検証に失敗しました action=verify reason={}", str(error))
+            await self._error_response(401, "認証が必要です", scope, receive, send)
+            return
+
+        async with self.session_scope_factory() as db:
+            try:
+                user_context = await create_user_context(db, identity)
+            except UserNotRegisteredError:
+                logger.warning("MCP Access IDに対応するUserがいません action=select email={}", identity.email)
+                await self._error_response(
+                    403,
+                    "このアカウントはInvestLogixに登録されていません",
+                    scope,
+                    receive,
+                    send,
+                )
+                return
+
+            scope[USER_CONTEXT_SCOPE_KEY] = user_context
+            await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _error_response(
+        status_code: int,
+        detail: str,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        await JSONResponse({"detail": detail}, status_code=status_code)(scope, receive, send)
+
+
+def get_user_context_from_mcp(context: Context) -> UserContext:
+    """SDKのリクエストコンテキストから認証済みユーザーコンテキストを得る。"""
+    request = context.request_context.request
+    if request is None:
+        raise RuntimeError("HTTPリクエストコンテキストがありません")
+
+    user_context = request.scope.get(USER_CONTEXT_SCOPE_KEY)
+    if user_context is None:
+        raise RuntimeError("認証済みユーザーコンテキストがありません")
+    return cast(UserContext, user_context)

--- a/src/api/stock/mcp/tools.py
+++ b/src/api/stock/mcp/tools.py
@@ -1,0 +1,59 @@
+"""MCPへ公開する、厳選した参照系ツール。"""
+
+from datetime import datetime
+
+from pydantic import ConfigDict, field_serializer
+
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
+from mcp.types import ToolAnnotations
+
+from .. import schemas
+from ..services.dividend_service import DividendService
+from ..services.holding_service import list_holdings as list_holdings_service
+from ..services.portfolio_service import PortfolioService
+from ..utils.datetime import to_jst
+from .middleware import get_user_context_from_mcp
+
+READ_ONLY = ToolAnnotations(read_only_hint=True, open_world_hint=False)
+
+
+class HoldingView(schemas.HoldingBase):
+    """MCP向け保有銘柄。内部のuser_idは公開しない。"""
+
+    last_updated: datetime
+    stock_name: str | None = None
+    security_type: str | None = None
+    currency: str | None = None
+    country: str | None = None
+    sector_name: str | None = None
+    account_holdings: list[schemas.AccountHolding]
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("last_updated")
+    def serialize_last_updated(self, value: datetime) -> str:
+        return to_jst(value).isoformat()
+
+
+def register_tools(server: MCPServer) -> None:
+    """MCPツールをサーバーへ登録する。"""
+
+    @server.tool(annotations=READ_ONLY)
+    async def get_portfolio_summary(ctx: Context) -> schemas.PortfolioSummary:
+        """現在のポートフォリオ全体の評価額、損益、配当、構成比を取得する。"""
+        user_context = get_user_context_from_mcp(ctx)
+        return await PortfolioService(user_context.db).get_portfolio_summary(user_context.user_id)
+
+    @server.tool(annotations=READ_ONLY)
+    async def list_holdings(ctx: Context, symbol: str | None = None) -> list[HoldingView]:
+        """保有銘柄を一覧する。symbolを指定すると1銘柄に絞り込む。"""
+        user_context = get_user_context_from_mcp(ctx)
+        holdings = await list_holdings_service(user_context.db, user_context.user_id, symbol=symbol)
+        return [HoldingView.model_validate(holding) for holding in holdings]
+
+    @server.tool(annotations=READ_ONLY)
+    async def get_monthly_dividends(ctx: Context) -> list[schemas.MonthlyDividend]:
+        """税・手数料控除後の月次配当額を時系列で取得する。"""
+        user_context = get_user_context_from_mcp(ctx)
+        rows = await DividendService(user_context.db).get_monthly_dividends(user_context.user_id)
+        return [schemas.MonthlyDividend.model_validate(row) for row in rows]

--- a/src/api/stock/models.py
+++ b/src/api/stock/models.py
@@ -129,14 +129,12 @@ class User(Base):
     user_id: ユーザーID
     username: ユーザー名
     email: メールアドレス
-    access_issuer: Cloudflare Access の issuer
-    access_subject: Cloudflare Access の利用者ID (sub)
     created_at: 登録日時
     line_user_id: LINE UserID（通知送信先）
     is_admin: 管理者権限フラグ
 
     認証はCloudflare Accessに委譲しているため、パスワードは保持しない。
-    (access_issuer, access_subject) が外部IDとの紐付けキーで、初回ログイン時に設定される。
+    email が Access の利用者との紐付けキーになる。
     """
 
     __tablename__ = "users"
@@ -144,13 +142,9 @@ class User(Base):
     user_id = Column(Integer, primary_key=True)  # [SYSTEM] ユーザーID
     username = Column(String(50), unique=True, nullable=False)  # [USER_INPUT] ユーザー名
     email = Column(String(100), unique=True, nullable=False)  # [USER_INPUT] メールアドレス
-    access_issuer = Column(String(255))  # [SYSTEM] Cloudflare Access の issuer
-    access_subject = Column(String(255))  # [SYSTEM] Cloudflare Access の利用者ID (sub)
     created_at = Column(DateTime(timezone=True), default=get_jst_now)  # [SYSTEM] 登録日時（JST）
     line_user_id = Column(String(100), unique=True)  # [USER_INPUT] LINE UserID
     is_admin = Column(Boolean, default=False)  # [SYSTEM] 管理者権限フラグ
-
-    __table_args__ = (UniqueConstraint("access_issuer", "access_subject", name="uq_users_access_identity"),)
 
     holdings = relationship("Holding", back_populates="user")
     transactions = relationship("Transaction", back_populates="user")

--- a/src/api/stock/services/user_service.py
+++ b/src/api/stock/services/user_service.py
@@ -15,27 +15,16 @@ class UserService:
 
     async def resolve_by_access_identity(self, identity: AccessIdentity) -> User | None:
         """
-        Cloudflare Access の外部IDからアプリ内ユーザーを解決する
-        - identity: 検証済みのAccess外部ID
+        Cloudflare Access の利用者IDからアプリ内ユーザーを解決する
+        - identity: 検証済みのAccess利用者ID
         - 戻り値: 対応するユーザー。アプリに登録されていない場合はNone
 
-        通常は (issuer, subject) の紐付けで引く。subject はIdP側でメールアドレスが
-        変わっても不変なため、恒久的な紐付けキーとして使える。
-        まだ紐付いていないユーザーは、Accessが確認済みのメールアドレスで初回だけ紐付ける。
+        Accessが確認済みのメールアドレスを紐付けキーにする。JWTの `sub` は
+        Access application ごとに変わりうるためWebとMCPで共通の鍵にできない。
+        IdP側でメールアドレスが変わったときは users.email を更新して追随する。
         """
-        user = await self._find_by_access_identity(identity)
-        if user:
-            return user
-
-        user = await self._find_unlinked_by_email(identity.email)
-        if user is None:
-            return None
-
-        user.access_issuer = identity.issuer
-        user.access_subject = identity.subject
-        await self.db.flush()
-        logger.info("UserをAccess IDへ紐付けました action=update user_id={}", user.user_id)
-        return user
+        result = await self.db.execute(select(User).where(User.email == identity.email))
+        return result.scalar_one_or_none()
 
     async def create_user(self, user: UserBase, is_admin: bool = False) -> User:
         """
@@ -44,8 +33,8 @@ class UserService:
         - is_admin: 管理者権限を付与するかどうか（デフォルトはFalse）
         - 戻り値: 作成されたユーザーエンティティ
 
-        Access IDはまだ紐付けない。作成したメールアドレスで初回ログインしたときに
-        resolve_by_access_identity が紐付ける。
+        ここで登録したメールアドレスがCloudflare Accessとの紐付けキーになるため、
+        IdP側で使うメールアドレスと一致させる必要がある。
         """
         result = await self.db.execute(
             select(User).where((User.username == user.username) | (User.email == user.email))
@@ -64,16 +53,3 @@ class UserService:
         await self.db.flush()
         logger.info("Userを登録しました action=create user_id={}", db_user.user_id)
         return db_user
-
-    async def _find_by_access_identity(self, identity: AccessIdentity) -> User | None:
-        result = await self.db.execute(
-            select(User).where(
-                User.access_issuer == identity.issuer,
-                User.access_subject == identity.subject,
-            )
-        )
-        return result.scalar_one_or_none()
-
-    async def _find_unlinked_by_email(self, email: str) -> User | None:
-        result = await self.db.execute(select(User).where(User.email == email, User.access_subject.is_(None)))
-        return result.scalar_one_or_none()

--- a/src/api/stock/user_context.py
+++ b/src/api/stock/user_context.py
@@ -1,0 +1,36 @@
+"""HTTPフレームワークに依存しない、認証済みユーザーの実行コンテキスト。"""
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .cloudflare_access import AccessIdentity
+from .database import set_rls_user_id
+from .models import User
+from .services.user_service import UserService
+
+
+class UserNotRegisteredError(Exception):
+    """Accessでは認証済みだが、InvestLogixに登録されていない利用者。"""
+
+
+@dataclass(frozen=True)
+class UserContext:
+    """同じ利用者に束縛されたUserとRLS設定済みDBセッション。"""
+
+    user: User
+    db: AsyncSession
+
+    @property
+    def user_id(self) -> int:
+        return self.user.user_id
+
+
+async def create_user_context(db: AsyncSession, identity: AccessIdentity) -> UserContext:
+    """外部IDをアプリ内ユーザーへ解決し、同じセッションへRLSを設定する。"""
+    user = await UserService(db).resolve_by_access_identity(identity)
+    if user is None:
+        raise UserNotRegisteredError
+
+    await set_rls_user_id(db, user.user_id)
+    return UserContext(user=user, db=db)

--- a/src/api/tests/auth/test_access_token.py
+++ b/src/api/tests/auth/test_access_token.py
@@ -69,11 +69,9 @@ def access_env(mocker):
 
 @pytest.mark.asyncio
 async def test_verify_valid_token(access_env: str):
-    """正しく署名されたトークンから外部IDを取り出せること"""
+    """正しく署名されたトークンから利用者IDを取り出せること"""
     identity = await verify_access_token(_issue_token(access_env))
 
-    assert identity.issuer == ISSUER
-    assert identity.subject == "access-user-uuid"
     assert identity.email == "user@example.com"
 
 

--- a/src/api/tests/auth/test_auth.py
+++ b/src/api/tests/auth/test_auth.py
@@ -2,14 +2,10 @@
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from stock.app import app
 from stock.auth import get_access_identity
 from stock.cloudflare_access import AccessIdentity
-from stock.schemas import UserBase
-from stock.services.user_service import UserService
-from tests.conftest import TEST_ACCESS_ISSUER
 
 
 def _authenticate_as(identity: AccessIdentity) -> None:
@@ -39,38 +35,11 @@ async def test_request_without_access_jwt_is_rejected(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_unregistered_access_user_is_rejected(client: AsyncClient):
     """Access認証は通ってもアプリに未登録の利用者を拒否すること"""
-    _authenticate_as(
-        AccessIdentity(issuer=TEST_ACCESS_ISSUER, subject="unknown-sub", email="stranger@example.com")
-    )
+    _authenticate_as(AccessIdentity(email="stranger@example.com"))
 
     response = await client.get("/api/v1/users/me")
 
     assert response.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_first_login_links_access_identity(client: AsyncClient, db_session: AsyncSession):
-    """初回ログインでAccessの外部IDが紐付き、以降はメールアドレスに依存せず解決されること"""
-    await UserService(db_session).create_user(UserBase(username="newcomer", email="newcomer@example.com"))
-    await db_session.commit()
-
-    # 初回はAccessが確認済みのメールアドレスで紐付く
-    _authenticate_as(
-        AccessIdentity(issuer=TEST_ACCESS_ISSUER, subject="newcomer-sub", email="newcomer@example.com")
-    )
-    first = await client.get("/api/v1/users/me")
-
-    assert first.status_code == 200
-    assert first.json()["username"] == "newcomer"
-
-    # IdP側でメールアドレスが変わっても、紐付いた subject で同じユーザーへ解決される
-    _authenticate_as(
-        AccessIdentity(issuer=TEST_ACCESS_ISSUER, subject="newcomer-sub", email="renamed@example.com")
-    )
-    second = await client.get("/api/v1/users/me")
-
-    assert second.status_code == 200
-    assert second.json()["user_id"] == first.json()["user_id"]
 
 
 @pytest.mark.asyncio

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from testcontainers.community.postgres import PostgresContainer
 
 from stock.app import app
-from stock.auth import get_access_identity, get_db_for_user
+from stock.auth import get_access_identity
 from stock.cloudflare_access import AccessIdentity
 from stock.database import get_db, settings
 from stock.models import Base
@@ -224,9 +224,8 @@ async def client(setup_database) -> AsyncGenerator[AsyncClient]:
             finally:
                 await session.close()
 
-    # get_db / get_db_for_user 依存性をオーバーライド
+    # get_dbだけを差し替え、User解決とRLS設定は本番と同じ依存性を通す
     app.dependency_overrides[get_db] = override_get_db
-    app.dependency_overrides[get_db_for_user] = override_get_db
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -145,9 +145,6 @@ async def db_session(setup_database) -> AsyncGenerator[AsyncSession]:
         yield session
 
 
-TEST_ACCESS_ISSUER = "https://test.cloudflareaccess.com"
-
-
 @pytest.fixture(autouse=True)
 def disable_dev_auth(monkeypatch) -> None:
     """開発用の認証迂回を無効化するフィクスチャー
@@ -161,21 +158,17 @@ def disable_dev_auth(monkeypatch) -> None:
 async def _create_authenticated_user(
     setup_database, username: str, email: str, is_admin: bool
 ) -> AccessIdentity:
-    """テストユーザーをDBに作成し、Cloudflare Accessの認証済み外部IDを差し替えるヘルパー
+    """テストユーザーをDBに作成し、Cloudflare Accessの認証済み利用者IDを差し替えるヘルパー
 
-    JWTの検証（get_access_identity）だけをオーバーライドし、外部IDからアプリ内ユーザーへの
+    JWTの検証（get_access_identity）だけをオーバーライドし、利用者IDからアプリ内ユーザーへの
     解決とRLS設定は本番と同じ経路を通す。
     """
     TestingSessionLocalFunc = sessionmaker(setup_database, class_=AsyncSession, expire_on_commit=False)
     async with TestingSessionLocalFunc() as session:
-        user = await UserService(session).create_user(
-            UserBase(username=username, email=email), is_admin=is_admin
-        )
-        identity = AccessIdentity(issuer=TEST_ACCESS_ISSUER, subject=f"access-{user.user_id}", email=email)
-        user.access_issuer = identity.issuer
-        user.access_subject = identity.subject
+        await UserService(session).create_user(UserBase(username=username, email=email), is_admin=is_admin)
         await session.commit()
 
+    identity = AccessIdentity(email=email)
     app.dependency_overrides[get_access_identity] = lambda: identity
     return identity
 

--- a/src/api/tests/mcp/__init__.py
+++ b/src/api/tests/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server tests."""

--- a/src/api/tests/mcp/test_mcp_server.py
+++ b/src/api/tests/mcp/test_mcp_server.py
@@ -15,22 +15,14 @@ from stock.mcp.app import mcp_http_app
 from stock.mcp.middleware import AccessUserContextMiddleware
 from stock.schemas import UserBase
 from stock.services.user_service import UserService
-from tests.conftest import TEST_ACCESS_ISSUER
 
 
 async def _create_user(engine: AsyncEngine, username: str, email: str) -> AccessIdentity:
     session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     async with session_factory() as session:
-        user = await UserService(session).create_user(UserBase(username=username, email=email))
-        identity = AccessIdentity(
-            issuer=TEST_ACCESS_ISSUER,
-            subject=f"access-{user.user_id}",
-            email=email,
-        )
-        user.access_issuer = identity.issuer
-        user.access_subject = identity.subject
+        await UserService(session).create_user(UserBase(username=username, email=email))
         await session.commit()
-    return identity
+    return AccessIdentity(email=email)
 
 
 def _session_scope_factory(engine: AsyncEngine):
@@ -75,11 +67,7 @@ async def test_mcp_rejects_request_without_access_jwt(setup_database: AsyncEngin
 
 @pytest.mark.asyncio
 async def test_mcp_rejects_unregistered_access_user(setup_database: AsyncEngine):
-    identity = AccessIdentity(
-        issuer=TEST_ACCESS_ISSUER,
-        subject="unknown-subject",
-        email="unknown@example.com",
-    )
+    identity = AccessIdentity(email="unknown@example.com")
     transport = httpx2.ASGITransport(app=_mcp_app(setup_database, identity))
 
     async with httpx2.AsyncClient(

--- a/src/api/tests/mcp/test_mcp_server.py
+++ b/src/api/tests/mcp/test_mcp_server.py
@@ -1,0 +1,172 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx2
+import pytest
+from mcp import Client
+from mcp.client.streamable_http import streamable_http_client
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from stock.app import app as api_app
+from stock.auth import get_access_identity
+from stock.cloudflare_access import AccessIdentity, AccessTokenError
+from stock.mcp.app import mcp_http_app
+from stock.mcp.middleware import AccessUserContextMiddleware
+from stock.schemas import UserBase
+from stock.services.user_service import UserService
+from tests.conftest import TEST_ACCESS_ISSUER
+
+
+async def _create_user(engine: AsyncEngine, username: str, email: str) -> AccessIdentity:
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        user = await UserService(session).create_user(UserBase(username=username, email=email))
+        identity = AccessIdentity(
+            issuer=TEST_ACCESS_ISSUER,
+            subject=f"access-{user.user_id}",
+            email=email,
+        )
+        user.access_issuer = identity.issuer
+        user.access_subject = identity.subject
+        await session.commit()
+    return identity
+
+
+def _session_scope_factory(engine: AsyncEngine):
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def test_session_scope() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    return test_session_scope
+
+
+def _mcp_app(engine: AsyncEngine, identity: AccessIdentity) -> AccessUserContextMiddleware:
+    async def provide_identity(token: str | None) -> AccessIdentity:
+        if token != "test-token":
+            raise AccessTokenError("テスト用Access JWTがありません")
+        return identity
+
+    return AccessUserContextMiddleware(
+        mcp_http_app,
+        identity_provider=provide_identity,
+        session_scope_factory=_session_scope_factory(engine),
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_request_without_access_jwt(setup_database: AsyncEngine):
+    identity = await _create_user(setup_database, "mcp-user", "mcp@example.com")
+    transport = httpx2.ASGITransport(app=_mcp_app(setup_database, identity))
+
+    async with httpx2.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/mcp", json={})
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_unregistered_access_user(setup_database: AsyncEngine):
+    identity = AccessIdentity(
+        issuer=TEST_ACCESS_ISSUER,
+        subject="unknown-subject",
+        email="unknown@example.com",
+    )
+    transport = httpx2.ASGITransport(app=_mcp_app(setup_database, identity))
+
+    async with httpx2.AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Cf-Access-Jwt-Assertion": "test-token"},
+    ) as client:
+        response = await client.post("/mcp", json={})
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mcp_lists_read_only_tools_and_keeps_user_data_separate(
+    client,
+    auth_user: AccessIdentity,
+    create_transaction,
+    create_dividend,
+    setup_database: AsyncEngine,
+):
+    await create_transaction(
+        {
+            "symbol": "8058",
+            "transaction_type": "buy",
+            "quantity": 100,
+            "price": 3000,
+            "account_type": "NISA(成長投資枠)",
+            "fee": 0,
+            "tax": 0,
+            "transaction_date": "2024-01-01T00:00:00+09:00",
+        }
+    )
+    await create_dividend(
+        {
+            "symbol": "8058",
+            "payment_date": "2024-03-01T00:00:00+09:00",
+            "shares_owned": 100,
+            "total_amount": 2000,
+            "tax": 400,
+            "fee": 100,
+        }
+    )
+
+    other_identity = await _create_user(setup_database, "other-user", "other@example.com")
+    api_app.dependency_overrides[get_access_identity] = lambda: other_identity
+    response = await client.post(
+        "/api/v1/transactions/",
+        json={
+            "symbol": "AAPL",
+            "transaction_type": "buy",
+            "quantity": 10,
+            "price": 36000,
+            "usd_price": 240,
+            "account_type": "NISA(成長投資枠)",
+            "fee": 0,
+            "tax": 0,
+            "transaction_date": "2024-01-01T00:00:00+09:00",
+        },
+    )
+    assert response.status_code == 200
+
+    mcp_app = _mcp_app(setup_database, auth_user)
+    transport = httpx2.ASGITransport(app=mcp_app)
+    async with (
+        mcp_http_app.router.lifespan_context(mcp_http_app),
+        httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            headers={"Cf-Access-Jwt-Assertion": "test-token"},
+        ) as http_client,
+        Client(streamable_http_client("http://test/mcp", http_client=http_client)) as mcp_client,
+    ):
+        tools = await mcp_client.list_tools()
+        holdings_result = await mcp_client.call_tool("list_holdings")
+        summary_result = await mcp_client.call_tool("get_portfolio_summary")
+        dividends_result = await mcp_client.call_tool("get_monthly_dividends")
+
+    assert {tool.name for tool in tools.tools} == {
+        "get_portfolio_summary",
+        "list_holdings",
+        "get_monthly_dividends",
+    }
+    assert all(tool.annotations and tool.annotations.read_only_hint for tool in tools.tools)
+    holdings = holdings_result.structured_content["result"]
+    assert [holding["symbol"] for holding in holdings] == ["8058"]
+    assert "user_id" not in holdings[0]
+    assert summary_result.structured_content["total_cost"] == 300000
+    assert dividends_result.structured_content["result"] == [
+        {"year": 2024, "month": 3, "total_dividend": 1500.0}
+    ]

--- a/src/api/uv.lock
+++ b/src/api/uv.lock
@@ -96,6 +96,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -447,6 +456,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -459,6 +481,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -558,6 +595,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -635,6 +699,44 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -700,6 +802,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/d4d1835488c0350424009dac5095b9a3e173bee12fd2e421ee27e2142c42/openai-2.48.0.tar.gz", hash = "sha256:231b1e7661dda14574986c2f71451e9d584b7fe69e0ee6480e12ed090b48fc16", size = 1093427, upload-time = "2026-07-23T20:15:50.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/2a/dcb891114e303c4379d4a498f10222e33eee540bcef4e1e493bd0af2b242/openai-2.48.0-py3-none-any.whl", hash = "sha256:c98df30aaaf93c51979f64d3e7c5b76464f8be0173368266229eb8fe6bd30f2c", size = 1648520, upload-time = "2026-07-23T20:15:48.052Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -944,6 +1058,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1120,6 +1248,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1132,6 +1273,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -1242,6 +1464,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542, upload-time = "2026-07-20T14:16:32.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516, upload-time = "2026-07-20T14:16:30.978Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1266,6 +1501,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jquants-api-client" },
     { name = "loguru" },
+    { name = "mcp" },
     { name = "openai" },
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
@@ -1300,6 +1536,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jquants-api-client", specifier = ">=2.3.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "mcp", specifier = ">=2.0.0" },
     { name = "openai", specifier = ">=2.48.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
@@ -1359,6 +1596,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/src/web/worker/index.ts
+++ b/src/web/worker/index.ts
@@ -1,5 +1,5 @@
 /**
- * フロントと同一オリジンで `/api/*` を受け、バックエンド（Cloud Run）へ転送する。
+ * `/api/*` と `/mcp` を、それぞれのCloud Runサービスへ転送する。
  *
  * 同一オリジンにすることが目的。このドメインは Cloudflare Access で保護されており、
  * Access は認証を通したリクエストにだけ `Cf-Access-Jwt-Assertion` を付けて Worker へ渡す。
@@ -12,6 +12,8 @@
 interface Env {
   /** バックエンドのオリジン。`wrangler secret put API_ORIGIN` で登録する */
   API_ORIGIN: string
+  /** MCP Cloud Runサービスのオリジン。`wrangler secret put MCP_ORIGIN` で登録する */
+  MCP_ORIGIN: string
 }
 
 /** ボディを持ちえないメソッド。これ以外はバッファに読み切ってから転送する */
@@ -20,7 +22,9 @@ const BODYLESS_METHODS = new Set(["GET", "HEAD"])
 export default {
   async fetch(request, env) {
     const url = new URL(request.url)
-    const target = new URL(url.pathname + url.search, env.API_ORIGIN)
+    const isMcpRequest = url.pathname === "/mcp" || url.pathname.startsWith("/mcp/")
+    const targetOrigin = isMcpRequest ? env.MCP_ORIGIN : env.API_ORIGIN
+    const target = new URL(url.pathname + url.search, targetOrigin)
 
     // Host は転送先URLから導出させる。Cloud Run は Host でルーティングするため、
     // 元の Host（フロントのドメイン）を引き継ぐと転送先に届かない

--- a/src/web/wrangler.jsonc
+++ b/src/web/wrangler.jsonc
@@ -18,9 +18,9 @@
     "directory": "./dist",
     // SPAのルートを index.html に落とす（クライアントルーティングを直リロードでも通す）
     "not_found_handling": "single-page-application",
-    // /api/* だけ Worker に渡す。それ以外はWorkerを起動せずアセット配信されるので
+    // /api/* とMCPエンドポイントだけ Worker に渡す。それ以外はWorkerを起動せずアセット配信されるので
     // Worker のリクエスト課金対象にならない
-    "run_worker_first": ["/api/*"]
+    "run_worker_first": ["/api/*", "/mcp", "/mcp/*"]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## 概要

Issue #441 Phase 2 として、Cloudflare Accessで保護された参照専用MCPサーバーを追加する。

- Python MCP SDK v2 / Streamable HTTPによるMCPエンドポイントと参照ツールを追加
- Cloudflare Access JWT検証、emailによるユーザー解決、PostgreSQL RLSをWeb/MCPで共通化
- MCP専用Cloud Run、サービスアカウント、Secret IAM、CDを追加
- Cloudflare Workerに `/mcp` のMCPプロキシを追加（オリジンは Worker Secret `MCP_ORIGIN`）

## 確認済み

- API: `uv run pytest`（194 passed）
- Web: `pnpm check`
- Web: `pnpm test`（182 passed）
- Infra: `tofu fmt -check` / `tofu validate`

## 補足

本番のCloudflare / Google Cloud設定と実画面での疎通確認が残っているため、Draft PRとして作成する。Issueの自動クローズは行わない。

外部環境のセットアップ手順は手元の作業メモとして扱い、リポジトリには含めない（`docs/tmp-*` を gitignore 済み）。

Refs #441
