### PR TITLE
Validate uv lockfile in CI

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -39,10 +39,11 @@ jobs:
           mode: firewall
 
       # ruffのバージョンはuv.lockを唯一の情報源とする（CI・pre-commit・ローカルで揃える）
+      # --locked で pyproject.toml と uv.lock の不整合を検出する。
       # リント目的なのでランタイム依存は入れず、ruffを含むdevグループのみ同期する
       - name: Install Ruff
         working-directory: src/api
-        run: sfw uv sync --frozen --only-group dev
+        run: sfw uv sync --locked --only-group dev
 
       # --no-sync がないと uv run が完全な依存に同期し直し、上の --only-group dev が無駄になる
       # line-lengthはpyproject.tomlの[tool.ruff]から読まれる

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Sync dependencies
         working-directory: src/api
-        run: sfw uv sync --frozen
+        run: sfw uv sync --locked
 
+      # 同期済みの環境を使い、uv run による再同期やlockfile更新を防ぐ
       - name: Run pytest (parallel)
         working-directory: src/api
-        run: uv run pytest -n auto
+        run: uv run --no-sync pytest -n auto


### PR DESCRIPTION
## 変更内容

- API CIのuv同期を`--frozen`から`--locked`へ変更した。
- テスト実行を`uv run --no-sync`へ変更した。

## 理由

- `--frozen`は`uv.lock`の最新性チェックを省略するため、`pyproject.toml`との不整合をCIで検出できない。
- 同期後の`uv run`が再同期・lockfile更新を行わないようにする。

## 影響

- CIがlockfileの更新漏れを検出し、コミット済みの依存関係だけで検証する。

## 確認

- `git diff --check`
- `uv lock --check --offline`