### PR TITLE
docs(infra): MCPツール一覧の同期間隔を追記

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -71,6 +71,8 @@ InvestLogix の本番 Google Cloud リソース（API/MCP Cloud Run Service / Jo
 
 MCPのAccess token lifetimeは5〜15分、grant sessionは1〜2週間を目安にする。OAuthはAccessが提供するため、MCPサーバー自身にOAuthエンドポイントやクライアントシークレットは置かない。
 
+Zero Trustダッシュボード側のツール一覧は約2時間ごとのバックグラウンド同期で更新されるため、登録直後は空のことがある。空のままなら、サーバーのステータスとCloud Runのログ（401ならJWT検証、403なら`users`未登録）を確認する。
+
 ### CD 用リソースと GitHub Actions Variables の同期
 - WIF / Artifact Registry / Deployer SA は OpenTofu 管理下にある。
 - ワークフロー側は GCP プロジェクト ID 等の識別子を YAML に書かない（public リポのため）。`tofu output` の値を GitHub の **Settings → Secrets and variables → Actions → Variables** に手動で登録する。


### PR DESCRIPTION
## 変更内容

`infra/README.md` の「MCPの初期構築」に、Zero Trustダッシュボードのツール一覧が約2時間ごとのバックグラウンド同期で更新される旨を追記した。

登録直後にツールが表示されなくても異常ではないが、手順書にその記載がないと不具合を疑って調査に入ってしまうため。あわせて、空のままだった場合の確認先（サーバーのステータスと Cloud Run のログ）も残した。401 ならAccess JWTの検証、403 なら `users` 未登録、と切り分けられる。

ドキュメントのみの変更で、コードとインフラ構成に変更はない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGXZyjd9JmNS1aScPuZjge)_